### PR TITLE
Fix: Prevent method not found warnings for lambdas and clinit

### DIFF
--- a/src/instructions/invoke.js
+++ b/src/instructions/invoke.js
@@ -142,7 +142,10 @@ async function invokestatic(frame, instruction, jvm, thread) {
     return;
   }
 
-  const jreMethod = jvm._jreFindMethod(className, methodName, descriptor);
+  let jreMethod = null;
+  if (!methodName.includes('lambda$')) {
+    jreMethod = jvm._jreFindMethod(className, methodName, descriptor);
+  }
 
   if (jreMethod) {
     const { params } = parseDescriptor(descriptor);

--- a/src/jvm.js
+++ b/src/jvm.js
@@ -249,7 +249,7 @@ class JVM {
       
       currentClass = this.jre[currentClass.super];
     }
-    if (this.verbose) {
+    if (this.verbose && methodName !== '<clinit>') {
       console.warn(`Method not found: ${className}.${methodName}${descriptor}`);
     }
     return null;


### PR DESCRIPTION
The JVM was producing 'Method not found' warnings when running Java programs that use lambda expressions. This was because the `invokestatic` instruction handler was incorrectly trying to find lambda methods in the JRE.

This commit fixes the issue by skipping the JRE method lookup for methods with 'lambda$' in their name.

Additionally, the 'Method not found' warning for `<clinit>` methods has been suppressed, as it is normal for a class to not have a static initializer.

A test case has been added to verify that a Java program with a lambda expression runs correctly and without warnings.

## Summary by Sourcery

Fix spurious 'Method not found' warnings for lambda methods and class initializers by skipping JRE lookup for methods named 'lambda$' and suppressing <clinit> warnings, and add tests to verify lambda support without warnings.

Bug Fixes:
- Skip JRE method lookup for methods containing 'lambda$' to prevent false 'Method not found' warnings
- Suppress 'Method not found' warnings for <clinit> static initializer methods

Enhancements:
- Enhance invokestatic instruction handler to conditionally skip JRE lookup for lambda methods
- Enhance JVM verbose logging to exclude warnings for <clinit> methods

Tests:
- Extend runJvmTest helper to capture and return console.warn messages
- Add a test case to verify that lambda expressions execute without producing 'Method not found' warnings