### PR TITLE
Preserve method entry locals during alias retargeting

### DIFF
--- a/src/passes/retargetUndefinedTypedAliasLoads.js
+++ b/src/passes/retargetUndefinedTypedAliasLoads.js
@@ -31,11 +31,13 @@ function rewriteCode(code, methodOrOptions = {}, maybeOptions = {}) {
   if (!cfg.blocks.length) return 0;
   const analysis = reachingDefinitions(code, cfg);
   const dominators = computeDominators(cfg);
+  const entryDefinitions = method ? entryDefinedLocals(method) : new Set();
   const replacements = [];
 
   for (let i = 0; i < items.length; i += 1) {
     const stale = aloadLocal(items[i]);
-    if (stale == null || hasDominatingDefinition(cfg, dominators, analysis, i, stale)) continue;
+    if (stale == null || entryDefinitions.has(stale) ||
+        hasDominatingDefinition(cfg, dominators, analysis, i, stale)) continue;
     const owner = fieldOwnerAtUse(items, i);
     const isAliasCopy = owner == null && astoreLocal(items[nextInstructionIndex(items, i)]) != null;
     if (!owner && !isAliasCopy) {
@@ -121,6 +123,12 @@ function parameterLocals(method) {
     local += descriptor === 'J' || descriptor === 'D' ? 2 : 1;
   }
   return out;
+}
+
+function entryDefinedLocals(method) {
+  const locals = new Set(parameterLocals(method).map((param) => param.local));
+  if (!(method.flags && method.flags.includes('static'))) locals.add('0');
+  return locals;
 }
 
 function argumentDescriptors(desc) {

--- a/test/retargetUndefinedTypedAliasLoads.test.js
+++ b/test/retargetUndefinedTypedAliasLoads.test.js
@@ -56,6 +56,56 @@ test('leaves defined locals alone', (t) => {
   t.end();
 });
 
+test('treats this as an entry definition instead of a same-typed checked alias', (t) => {
+  const method = {
+    flags: [],
+    descriptor: '()V',
+  };
+  const code = {
+    codeItems: [
+      { instruction: { op: 'aload', arg: '3' } },
+      { instruction: 'iconst_0' },
+      { instruction: 'aaload' },
+      { instruction: { op: 'checkcast', arg: 'w' } },
+      { instruction: { op: 'astore', arg: '4' } },
+      { instruction: 'aload_0' },
+      { instruction: { op: 'getfield', arg: ['Field', 'w', ['M', 'Lvj;']] } },
+      { instruction: 'pop' },
+      { instruction: 'return' },
+    ],
+    exceptionTable: [],
+  };
+
+  t.equal(rewriteCode(code, method), 0);
+  t.equal(code.codeItems[5].instruction, 'aload_0');
+  t.end();
+});
+
+test('treats reference parameters as entry definitions', (t) => {
+  const method = {
+    flags: [],
+    descriptor: '(Lw;)V',
+  };
+  const code = {
+    codeItems: [
+      { instruction: { op: 'aload', arg: '3' } },
+      { instruction: 'iconst_0' },
+      { instruction: 'aaload' },
+      { instruction: { op: 'checkcast', arg: 'w' } },
+      { instruction: { op: 'astore', arg: '4' } },
+      { instruction: 'aload_1' },
+      { instruction: { op: 'getfield', arg: ['Field', 'w', ['M', 'Lvj;']] } },
+      { instruction: 'pop' },
+      { instruction: 'return' },
+    ],
+    exceptionTable: [],
+  };
+
+  t.equal(rewriteCode(code, method), 0);
+  t.equal(code.codeItems[5].instruction, 'aload_1');
+  t.end();
+});
+
 test('retargets undefined reference-array load to unique compatible parameter', (t) => {
   const method = {
     flags: [],

--- a/test/retargetUndefinedTypedAliasLoads.test.js
+++ b/test/retargetUndefinedTypedAliasLoads.test.js
@@ -77,7 +77,17 @@ test('treats this as an entry definition instead of a same-typed checked alias',
   };
 
   t.equal(rewriteCode(code, method), 0);
-  t.equal(code.codeItems[5].instruction, 'aload_0');
+  t.deepEqual(code.codeItems.map((item) => item.instruction), [
+    { op: 'aload', arg: '3' },
+    'iconst_0',
+    'aaload',
+    { op: 'checkcast', arg: 'w' },
+    { op: 'astore', arg: '4' },
+    'aload_0',
+    { op: 'getfield', arg: ['Field', 'w', ['M', 'Lvj;']] },
+    'pop',
+    'return',
+  ]);
   t.end();
 });
 


### PR DESCRIPTION
Fixes Kreijstal/dekobloko-work#17.

## What changed

- Treat `this` and method parameters as definitions that exist at method entry.
- Prevent the undefined-alias repair pass from replacing those valid locals with a later same-typed alias.
- Add regressions for both instance receivers and reference parameters.

## Root cause

The pass only considered bytecode stores when checking whether an `aload` local was defined. In `w.d(int)`, that made `aload_0` look undefined and retargeted it to the loop cursor in local 4, corrupting the field receiver and stalling Dekobloko at “Unpacking graphics”.

## Validation

- `node node_modules/tape/bin/tape test/retargetUndefinedTypedAliasLoads.test.js` — 14/14 pass.
- Exact issue reproduction through `bulk-pipeline.js` — 1/1 processed, 0 failed.
- `javap` confirms the affected instruction remains `aload_0; getfield w.M`.

## Summary by Sourcery

Preserve method entry locals as valid definitions when retargeting undefined typed alias loads to avoid corrupting receivers and parameters.

Bug Fixes:
- Prevent the alias retargeting pass from replacing `this` and reference parameters with later same-typed aliases when they are already defined at method entry.

Enhancements:
- Introduce tracking of entry-defined locals (including non-static `this`) and exclude them from undefined-alias repairs during analysis.

Tests:
- Add regression tests ensuring `this` and reference parameters are treated as entry definitions and are not retargeted by the undefined-typed-alias load pass.