### PR TITLE
Fix decompiled game runtime parity

### DIFF
--- a/src/core/jvm.js
+++ b/src/core/jvm.js
@@ -2132,14 +2132,12 @@ class JVM {
         for (const item of items) value.add(resolve(item));
       } else if (ArrayBuffer.isView(value)) {
         return value;
+      } else if (value instanceof String) {
+        // Boxed strings expose enumerable, read-only character indices and
+        // cannot contain decoded thread placeholders.
+        return value;
       } else {
-        for (const key of Object.keys(value)) {
-          const descriptor = Object.getOwnPropertyDescriptor(value, key);
-          // Boxed strings expose enumerable, read-only character indices.
-          // They cannot contain thread placeholders and assigning them throws.
-          if (descriptor && descriptor.writable === false && !descriptor.set) continue;
-          value[key] = resolve(value[key]);
-        }
+        for (const key of Object.keys(value)) value[key] = resolve(value[key]);
       }
       return value;
     };

--- a/src/core/jvm.js
+++ b/src/core/jvm.js
@@ -2133,7 +2133,13 @@ class JVM {
       } else if (ArrayBuffer.isView(value)) {
         return value;
       } else {
-        for (const key of Object.keys(value)) value[key] = resolve(value[key]);
+        for (const key of Object.keys(value)) {
+          const descriptor = Object.getOwnPropertyDescriptor(value, key);
+          // Boxed strings expose enumerable, read-only character indices.
+          // They cannot contain thread placeholders and assigning them throws.
+          if (descriptor && descriptor.writable === false && !descriptor.set) continue;
+          value[key] = resolve(value[key]);
+        }
       }
       return value;
     };

--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -578,11 +578,13 @@ function buildExceptionModel(classes) {
   const methodThrows = new Map(); // `owner#name#descriptor` -> [internal throw names]
   const superOf = new Map();      // owner internal name -> superclass internal name
   const classInfo = new Map();    // owner internal name -> parsed class
+  const sourceNameToInternal = new Map(); // rendered Java type -> owner internal name
   const instantiatedTypes = new Set();
   for (const cls of classes || []) {
     const owner = cls.className;
     if (!owner) continue;
     classInfo.set(owner, cls);
+    sourceNameToInternal.set(simplifyType(javaTypeFromInternalName(owner)), owner);
     if (cls.superClassName) superOf.set(owner, cls.superClassName);
     for (const item of cls.items || []) {
       if (item.type !== 'method' || !item.method) continue;
@@ -599,7 +601,7 @@ function buildExceptionModel(classes) {
       }
     }
   }
-  return { methodThrows, superOf, classInfo, instantiatedTypes };
+  return { methodThrows, superOf, classInfo, sourceNameToInternal, instantiatedTypes };
 }
 
 function hasUnimplementedAbstractMethods(cls, model) {
@@ -838,6 +840,34 @@ function formatStaticInitializer(code, localState, cls, options = {}) {
   body.splice(0, body.length, ...normalizeSyntheticVariableScopes(body));
   assertNoFallback(body, { className: cls.className, methodName: '<clinit>', descriptor: '()V' });
   if (!body.length) return formatBlock('static', body);
+
+  // Keep ordinary initializer bytecode in Java's actual static-initializer
+  // construct. Moving every body into a helper changes the shape of <clinit>
+  // and exposes a partially initialized class to runtimes while that helper is
+  // executing. A JVM return inside a structured branch is represented as a
+  // break from a labelled block because Java forbids return statements in an
+  // initializer.
+  const hasEarlyReturn = body.some((line) => String(line).trim() === 'return;');
+  if (!bodyCompletesAbruptly(body)) {
+    if (!hasEarlyReturn) return formatBlock('static', body);
+
+    let label = '$cfr$clinit';
+    const renderedBody = body.join('\n');
+    while (renderedBody.includes(`${label}:`)) label += '$';
+    const labelledBody = body.map((line) => {
+      const text = String(line);
+      if (text.trim() !== 'return;') return text;
+      return `${text.slice(0, text.length - text.trimStart().length)}break ${label};`;
+    });
+    return formatBlock('static', [
+      `${label}: {`,
+      ...labelledBody.map((line) => `    ${line}`),
+      '}',
+    ]);
+  }
+
+  // Java rejects an initializer that provably cannot complete normally. Retain
+  // a helper only for that source-language edge case.
   const methodNames = new Set((cls.items || [])
     .filter((item) => item && item.type === 'method' && item.method)
     .map((item) => item.method.name));
@@ -1016,6 +1046,10 @@ function loadInt(index) {
 }
 
 function decompileCode(code, method, cls, localState, options = {}) {
+  // Linear emitters are also called by nested structuring strategies that have
+  // their own option bags.  Keep the run-wide hierarchy on the shared local
+  // state so expression coercion remains cross-class-aware in every path.
+  localState.exceptionModel = options.exceptionModel || localState.exceptionModel;
   const codeItemsForSelection = code.codeItems || [];
   let controlTransfers = 0;
   let hasSuppressedCleanup = false;
@@ -1214,6 +1248,53 @@ function isReferenceTypeAssignable(sourceType, targetType, model) {
     }
   }
   return false;
+}
+
+const JAVA_PRIMITIVE_TYPES = new Set([
+  'boolean', 'byte', 'char', 'short', 'int', 'long', 'float', 'double', 'void',
+]);
+
+function internalNameForSourceType(type, model) {
+  const rendered = simplifyType(type);
+  if (model && model.sourceNameToInternal && model.sourceNameToInternal.has(rendered)) {
+    return model.sourceNameToInternal.get(rendered);
+  }
+  const wellKnown = {
+    Object: 'java/lang/Object',
+    Cloneable: 'java/lang/Cloneable',
+    Serializable: 'java/io/Serializable',
+  };
+  return wellKnown[rendered] || rendered.replace(/\./g, '/');
+}
+
+// Source expressions can be more specific than a bytecode descriptor's
+// parameter or storage type.  A Java widening reference conversion needs no
+// cast; forcing it through Object creates a real checkcast in the recompiled
+// bytecode.  Arrays are covariant for reference components, and every array is
+// assignable to Object, Cloneable, and Serializable.
+function isSourceReferenceTypeAssignable(sourceType, targetType, model) {
+  const source = simplifyType(sourceType);
+  const target = simplifyType(targetType);
+  if (source === target) return true;
+  if (JAVA_PRIMITIVE_TYPES.has(source) || JAVA_PRIMITIVE_TYPES.has(target)) return false;
+
+  const sourceIsArray = source.endsWith('[]');
+  const targetIsArray = target.endsWith('[]');
+  if (sourceIsArray && !targetIsArray) {
+    return target === 'Object' || target === 'Cloneable' || target === 'Serializable'
+      || target === 'java.lang.Object' || target === 'java.lang.Cloneable'
+      || target === 'java.io.Serializable';
+  }
+  if (sourceIsArray !== targetIsArray) return false;
+  if (sourceIsArray) {
+    return isSourceReferenceTypeAssignable(source.slice(0, -2), target.slice(0, -2), model);
+  }
+
+  return isReferenceTypeAssignable(
+    internalNameForSourceType(source, model),
+    internalNameForSourceType(target, model),
+    model,
+  );
 }
 
 function isInstanceofTypeCompatible(sourceType, testedType, model) {
@@ -2834,11 +2915,11 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
     }
 
     if (op === 'invokevirtual' || op === 'invokeinterface') {
-      emitVirtualCall(lines, stack, instruction.arg);
+      emitVirtualCall(lines, stack, instruction.arg, localState);
       continue;
     }
     if (op === 'invokestatic') {
-      emitStaticCall(lines, stack, instruction.arg, currentInternalClassName);
+      emitStaticCall(lines, stack, instruction.arg, currentInternalClassName, localState);
       continue;
     }
     if (op === 'invokespecial') {
@@ -2921,7 +3002,7 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
   return lines;
 }
 
-function emitVirtualCall(lines, stack, arg) {
+function emitVirtualCall(lines, stack, arg, localState) {
   const ref = parseMemberRef(arg);
   const descriptor = parseDescriptor(ref.descriptor);
   const args = popArgs(stack, descriptor.params.length);
@@ -2953,7 +3034,7 @@ function emitVirtualCall(lines, stack, arg) {
     return;
   }
 
-  const renderedArgs = formatCallArguments(ref, descriptor, args, receiver);
+  const renderedArgs = formatCallArguments(ref, descriptor, args, localState && localState.exceptionModel);
   const call = `${wrap(receiver, 100)}.${ref.name}(${renderedArgs.join(', ')})`;
   const returnType = simplifyType(descriptor.returnType);
   if (returnType === 'void') {
@@ -2963,12 +3044,12 @@ function emitVirtualCall(lines, stack, arg) {
   }
 }
 
-function emitStaticCall(lines, stack, arg, currentInternalClassName) {
+function emitStaticCall(lines, stack, arg, currentInternalClassName, localState) {
   const ref = parseMemberRef(arg);
   const descriptor = parseDescriptor(ref.descriptor);
   const args = popArgs(stack, descriptor.params.length);
   const owner = ref.owner === currentInternalClassName ? simpleClassName(ref.owner) : javaTypeFromInternalName(ref.owner);
-  const renderedArgs = formatCallArguments(ref, descriptor, args, null);
+  const renderedArgs = formatCallArguments(ref, descriptor, args, localState && localState.exceptionModel);
   const call = `${owner}.${ref.name}(${renderedArgs.join(', ')})`;
   const returnType = simplifyType(descriptor.returnType);
   if (returnType === 'void') {
@@ -2980,7 +3061,8 @@ function emitStaticCall(lines, stack, arg, currentInternalClassName) {
 
 const NUMERIC_PRIMITIVES = new Set(['byte', 'short', 'char', 'int', 'long', 'float', 'double']);
 
-function formatCallArguments(ref, descriptor, args) {
+function formatCallArguments(ref, descriptor, args, exceptionModel) {
+  const mustPinReferenceOverload = callHasApplicableOverload(ref, descriptor, args, exceptionModel);
   return args.map((arg, index) => {
     if (shouldRenderCharArgument(ref, descriptor, index, arg)) {
       return formatCharLiteral(Number(arg.code));
@@ -2990,7 +3072,12 @@ function formatCallArguments(ref, descriptor, args) {
     if (target && arg.code === 'null' && !primitiveTargets.has(simplifyType(target))) {
       return `(${simplifyType(target)}) null`;
     }
-    const value = coerceExpressionForType(arg, target || arg.type);
+    const value = coerceExpressionForType(
+      arg,
+      target || arg.type,
+      exceptionModel,
+      !mustPinReferenceOverload,
+    );
     // Pin the overload: an argument whose rendered type is a *different*
     // numeric primitive than the descriptor's parameter can make javac
     // resolve a more specific overload (e.g. a byte arg to a:(II)I selects
@@ -3000,6 +3087,68 @@ function formatCallArguments(ref, descriptor, args) {
       return `(${target}) ${wrap(value, 90)}`;
     }
     return value.code;
+  });
+}
+
+function methodDescriptorsNamed(owner, name, model) {
+  const descriptors = [];
+  const pending = [owner];
+  const seen = new Set();
+  while (pending.length) {
+    const current = pending.pop();
+    if (!current || seen.has(current)) continue;
+    seen.add(current);
+    const info = model && model.classInfo ? model.classInfo.get(current) : null;
+    if (!info) continue;
+    for (const item of info.items || []) {
+      const method = item && item.type === 'method' ? item.method : null;
+      if (method && method.name === name) descriptors.push(method.descriptor);
+    }
+    if (info.superClassName) pending.push(info.superClassName);
+    pending.push(...(info.interfaces || []));
+  }
+  return descriptors;
+}
+
+function isMethodInvocationConvertible(sourceType, targetType, model) {
+  const source = simplifyType(sourceType);
+  const target = simplifyType(targetType);
+  if (source === target) return true;
+  const wideningPrimitives = {
+    byte: new Set(['short', 'int', 'long', 'float', 'double']),
+    short: new Set(['int', 'long', 'float', 'double']),
+    char: new Set(['int', 'long', 'float', 'double']),
+    int: new Set(['long', 'float', 'double']),
+    long: new Set(['float', 'double']),
+    float: new Set(['double']),
+  };
+  if (wideningPrimitives[source]) return wideningPrimitives[source].has(target);
+  if (JAVA_PRIMITIVE_TYPES.has(source) || JAVA_PRIMITIVE_TYPES.has(target)) return false;
+  return isSourceReferenceTypeAssignable(source, target, model);
+}
+
+function callHasApplicableOverload(ref, descriptor, args, model) {
+  if (!model || !model.classInfo) return false;
+  // Arguments that already need an exact primitive/reference coercion are
+  // rendered with the descriptor type.  Only proven widening references are
+  // left at their source type and can affect overload selection.
+  const renderedTypes = (descriptor.params || []).map((target, index) => {
+    const arg = args[index];
+    return arg && arg.code !== 'null'
+      && isSourceReferenceTypeAssignable(arg.type, target, model)
+      ? simplifyType(arg.type)
+      : simplifyType(target);
+  });
+  const descriptors = methodDescriptorsNamed(ref.owner, ref.name, model);
+  return descriptors.some((candidateDescriptor) => {
+    if (!candidateDescriptor || candidateDescriptor === ref.descriptor) return false;
+    const candidate = parseDescriptor(candidateDescriptor);
+    if ((candidate.params || []).length !== renderedTypes.length) return false;
+    return candidate.params.every((target, index) => {
+      const arg = args[index];
+      if (arg && arg.code === 'null') return !JAVA_PRIMITIVE_TYPES.has(simplifyType(target));
+      return isMethodInvocationConvertible(renderedTypes[index], target, model);
+    });
   });
 }
 
@@ -3027,7 +3176,7 @@ function emitSpecialCall(lines, stack, arg, method, currentClassName, currentInt
   const ref = parseMemberRef(arg);
   const descriptor = parseDescriptor(ref.descriptor);
   const args = popArgs(stack, descriptor.params.length);
-  const renderedArgs = formatCallArguments(ref, descriptor, args);
+  const renderedArgs = formatCallArguments(ref, descriptor, args, localState && localState.exceptionModel);
   const rawReceiver = pop(stack);
   const ownerTypeForReceiver = javaTypeFromInternalName(ref.owner);
   const receiver = rawReceiver.code === 'this'
@@ -5747,15 +5896,15 @@ function renderStoreExpression(value) {
   return expr(`new ${literal.elementType}[]{${elements.join(', ')}}`, `${literal.elementType}[]`);
 }
 
-function coerceExpressionForType(value, targetType) {
+function coerceExpressionForType(value, targetType, exceptionModel = null, allowWideningReference = true) {
   if (!value) return value;
   const type = simplifyType(targetType);
   if (value.conditional) {
     const { condition, trueValue, falseValue } = value.conditional;
     return conditionalExpr(
       condition,
-      coerceExpressionForType(trueValue, type),
-      coerceExpressionForType(falseValue, type),
+      coerceExpressionForType(trueValue, type, exceptionModel, allowWideningReference),
+      coerceExpressionForType(falseValue, type, exceptionModel, allowWideningReference),
       type,
     );
   }
@@ -5764,8 +5913,8 @@ function coerceExpressionForType(value, targetType) {
       const { condition, trueValue, falseValue } = value.conditional;
       return conditionalExpr(
         condition,
-        coerceExpressionForType(trueValue, 'boolean'),
-        coerceExpressionForType(falseValue, 'boolean'),
+        coerceExpressionForType(trueValue, 'boolean', exceptionModel, allowWideningReference),
+        coerceExpressionForType(falseValue, 'boolean', exceptionModel, allowWideningReference),
         'boolean',
       );
     }
@@ -5791,6 +5940,9 @@ function coerceExpressionForType(value, targetType) {
   const primitive = new Set(['boolean', 'byte', 'char', 'short', 'int', 'long', 'float', 'double', 'void']);
   if (!primitive.has(type) && value.type !== type && value.code !== 'null') {
     const sourceType = simplifyType(value.type);
+    if (allowWideningReference && isSourceReferenceTypeAssignable(sourceType, type, exceptionModel)) {
+      return { ...value, type };
+    }
     const sourceIsKnownReference = !primitive.has(sourceType) && sourceType !== 'Object';
     const sourceNeedsBridge = sourceIsKnownReference || /^stack(?:In|Out)_/.test(value.code);
     const operand = sourceNeedsBridge ? `(Object) ${wrap(value, 90)}` : wrap(value, 90);
@@ -5823,11 +5975,12 @@ function materializeDuplicatedValue(value, lines, localState) {
 // spilled too), which is always safe: spilling a pure re-read changes nothing.
 function materializeStackFieldReads(stack, fieldName, lines, localState) {
   if (!fieldName) return;
-  const needle = `.${fieldName}`;
+  const escapedFieldName = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const fieldRead = new RegExp(`(^|[^A-Za-z0-9_$])${escapedFieldName}([^A-Za-z0-9_$]|$)`);
   for (let i = 0; i < stack.length; i += 1) {
     const value = stack[i];
     if (!value || typeof value.code !== 'string') continue;
-    if (!value.code.includes(needle)) continue;
+    if (!fieldRead.test(value.code)) continue;
     if (value.newArraySpill || value.arrayLiteral || value.stringBuilderPieces) continue;
     const rendered = renderStoreExpression(value);
     const name = localState.nextSyntheticName('fieldTemp');
@@ -5992,8 +6145,10 @@ module.exports = {
   buildExceptionModel,
   _internals: {
     binaryExpr,
+    coerceExpressionForType,
     dropUnthrowableProtectedRows,
     isCheckedThrow,
+    isSourceReferenceTypeAssignable,
     removeImpossibleCheckedCatchBlocks,
     simplifyBitwiseComplementComparison,
   },

--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -584,7 +584,7 @@ function buildExceptionModel(classes) {
     const owner = cls.className;
     if (!owner) continue;
     classInfo.set(owner, cls);
-    sourceNameToInternal.set(simplifyType(javaTypeFromInternalName(owner)), owner);
+    sourceNameToInternal.set(javaTypeFromInternalName(owner), owner);
     if (cls.superClassName) superOf.set(owner, cls.superClassName);
     for (const item of cls.items || []) {
       if (item.type !== 'method' || !item.method) continue;
@@ -847,7 +847,8 @@ function formatStaticInitializer(code, localState, cls, options = {}) {
   // executing. A JVM return inside a structured branch is represented as a
   // break from a labelled block because Java forbids return statements in an
   // initializer.
-  const hasEarlyReturn = body.some((line) => String(line).trim() === 'return;');
+  const isVoidReturn = (line) => /^return\s*;$/.test(String(line).trim());
+  const hasEarlyReturn = body.some(isVoidReturn);
   if (!bodyCompletesAbruptly(body)) {
     if (!hasEarlyReturn) return formatBlock('static', body);
 
@@ -856,7 +857,7 @@ function formatStaticInitializer(code, localState, cls, options = {}) {
     while (renderedBody.includes(`${label}:`)) label += '$';
     const labelledBody = body.map((line) => {
       const text = String(line);
-      if (text.trim() !== 'return;') return text;
+      if (!isVoidReturn(text)) return text;
       return `${text.slice(0, text.length - text.trimStart().length)}break ${label};`;
     });
     return formatBlock('static', [
@@ -3098,14 +3099,26 @@ function methodDescriptorsNamed(owner, name, model) {
     const current = pending.pop();
     if (!current || seen.has(current)) continue;
     seen.add(current);
-    const info = model && model.classInfo ? model.classInfo.get(current) : null;
-    if (!info) continue;
-    for (const item of info.items || []) {
-      const method = item && item.type === 'method' ? item.method : null;
-      if (method && method.name === name) descriptors.push(method.descriptor);
+    const corpusInfo = model && model.classInfo ? model.classInfo.get(current) : null;
+    if (corpusInfo) {
+      for (const item of corpusInfo.items || []) {
+        const method = item && item.type === 'method' ? item.method : null;
+        if (method && method.name === name) descriptors.push(method.descriptor);
+      }
+      if (corpusInfo.superClassName) pending.push(corpusInfo.superClassName);
+      pending.push(...(corpusInfo.interfaces || []));
+      continue;
     }
-    if (info.superClassName) pending.push(info.superClassName);
-    pending.push(...(info.interfaces || []));
+
+    const jreInfo = jreClassInfo(current);
+    if (!jreInfo) continue;
+    const candidates = [
+      ...(jreInfo.methods.get(name) || []),
+      ...(jreInfo.staticMethods.get(name) || []),
+    ];
+    for (const candidate of candidates) descriptors.push(candidate.descriptor);
+    if (jreInfo.superName) pending.push(jreInfo.superName);
+    pending.push(...(jreInfo.interfaces || []));
   }
   return descriptors;
 }
@@ -5940,11 +5953,13 @@ function coerceExpressionForType(value, targetType, exceptionModel = null, allow
   const primitive = new Set(['boolean', 'byte', 'char', 'short', 'int', 'long', 'float', 'double', 'void']);
   if (!primitive.has(type) && value.type !== type && value.code !== 'null') {
     const sourceType = simplifyType(value.type);
-    if (allowWideningReference && isSourceReferenceTypeAssignable(sourceType, type, exceptionModel)) {
+    const isAssignable = isSourceReferenceTypeAssignable(sourceType, type, exceptionModel);
+    if (allowWideningReference && isAssignable) {
       return { ...value, type };
     }
     const sourceIsKnownReference = !primitive.has(sourceType) && sourceType !== 'Object';
-    const sourceNeedsBridge = sourceIsKnownReference || /^stack(?:In|Out)_/.test(value.code);
+    const sourceNeedsBridge = !isAssignable
+      && (sourceIsKnownReference || /^stack(?:In|Out)_/.test(value.code));
     const operand = sourceNeedsBridge ? `(Object) ${wrap(value, 90)}` : wrap(value, 90);
     return expr(`(${type}) ${operand}`, type, 90);
   }

--- a/src/instructions/object.js
+++ b/src/instructions/object.js
@@ -156,7 +156,7 @@ module.exports = {
     const [_, className, [fieldName, descriptor]] = instruction.arg;
     const objRef = frame.stack.pop();
     if (objRef === null) {
-      throw new Error('NullPointerException');
+      throw { type: 'java/lang/NullPointerException', message: null };
     }
     const fieldKey = resolveInstanceFieldKey(jvm, objRef, className, fieldName);
     const value = fieldKey ? objRef.fields[fieldKey] : undefined;
@@ -172,7 +172,7 @@ module.exports = {
     const value = frame.stack.pop();
     const objRef = frame.stack.pop();
     if (objRef === null) {
-      throw new Error('NullPointerException');
+      throw { type: 'java/lang/NullPointerException', message: null };
     }
     const fieldKey = resolveInstanceFieldKey(jvm, objRef, className, fieldName) || `${className}.${fieldName}`;
     if (typeof process !== 'undefined' && process.env && process.env.JVM_DEBUG_PUTFIELD &&

--- a/src/jit/JitCompiler.js
+++ b/src/jit/JitCompiler.js
@@ -215,6 +215,11 @@ class JitCompiler {
       return this.supportCache.get(method);
     }
 
+    if (method.name === "<init>" || method.name === "<clinit>") {
+      this.supportCache.set(method, false);
+      return false;
+    }
+
     const code = method.attributes.find((attr) => attr.type === "code");
     if (!code) {
       this.supportCache.set(method, false);
@@ -253,8 +258,7 @@ class JitCompiler {
       return op && (doubleOps.has(op) || floatOps.has(op) || integerOps.has(op) || longOps.has(op) || op === "i2d" ||
         op === "newarray" && (item.instruction.arg === "double" || item.instruction.arg === "float" || item.instruction.arg === "int"));
     });
-    const eligibleShape = hasNumericHotPath || this.hasBackwardBranch(method) ||
-      this.isSimpleConstructor(method, codeItems);
+    const eligibleShape = hasNumericHotPath || this.hasBackwardBranch(method);
 
     const allowed = new Set([
       "aconst_null", "aload", "aload_0", "aload_1", "aload_2", "aload_3",
@@ -370,29 +374,6 @@ class JitCompiler {
 
     this.codegenSupportCache.set(method, supported);
     return supported;
-  }
-
-  isSimpleConstructor(method, codeItems) {
-    if (method.name !== "<init>") {
-      return false;
-    }
-
-    const allowed = new Set([
-      "aload", "aload_0", "aload_1", "aload_2", "aload_3",
-      "bipush", "dconst_0", "dconst_1", "iconst_0", "iconst_1",
-      "iconst_2", "iconst_3", "iconst_4", "iconst_5", "invokespecial",
-      "ldc", "ldc2_w", "putfield", "return", "sipush",
-    ]);
-
-    return codeItems.every((item) => {
-      if (!item.instruction) return true;
-      const instruction = item.instruction;
-      const op = typeof instruction === "string" ? instruction : instruction.op;
-      if (!allowed.has(op)) return false;
-      if (op !== "invokespecial") return true;
-      const [, className, [methodName, descriptor]] = instruction.arg;
-      return methodName === "<init>" && descriptor === "()V" && className === "java/lang/Object";
-    });
   }
 
   hasJitSafeMonitorBody(codeItems) {

--- a/src/jit/WasmJit.js
+++ b/src/jit/WasmJit.js
@@ -502,11 +502,15 @@ class MethodTranslator {
       t,
       idx: isGet
         ? this.addImport(name, [T.ref], [t], (obj) => {
-          if (obj === null || obj === undefined) throw new Error('NullPointerException');
+          if (obj === null || obj === undefined) {
+            throw { type: 'java/lang/NullPointerException', message: null };
+          }
           return toWasmValue(t, obj.fields[resolveKey(obj)]);
         })
         : this.addImport(name, [T.ref, t], [], (obj, v) => {
-          if (obj === null || obj === undefined) throw new Error('NullPointerException');
+          if (obj === null || obj === undefined) {
+            throw { type: 'java/lang/NullPointerException', message: null };
+          }
           obj.fields[resolveKey(obj)] = v;
         }),
     };
@@ -1264,6 +1268,10 @@ class WasmJit {
   // shared gating/warmup/compile; returns {st, blk} when the frame can run now
   prepare(frame) {
     if (!this.enabled || !frame || !frame.method || !frame.instructions) return null;
+    // Object construction and class initialization have observable all-or-
+    // nothing ordering. A partial Wasm exit around new/invokespecial can leave
+    // an allocated object visible without having run the rest of <init>.
+    if (frame.method.name === '<init>' || frame.method.name === '<clinit>') return null;
     const debug = this.jvm.debugManager;
     if (debug && debug.debugMode) return null;
 

--- a/src/jre/java/lang/StringBuilder.js
+++ b/src/jre/java/lang/StringBuilder.js
@@ -108,6 +108,10 @@ module.exports = {
       obj.value += valueAsString(args[0]);
       return obj;
     },
+    'append(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;': (jvm, obj, args) => {
+      obj.value += valueAsString(args[0]);
+      return obj;
+    },
     'append(Ljava/lang/Object;)Ljava/lang/StringBuilder;': (jvm, obj, args) => {
       obj.value += valueAsString(args[0]);
       return obj;

--- a/src/jre/javax/swing/SwingUtilities.js
+++ b/src/jre/javax/swing/SwingUtilities.js
@@ -1,7 +1,7 @@
 module.exports = {
   super: 'java/lang/Object',
   staticMethods: {
-    'isRightMouseButton(Ljava/awt/event/MouseEvent;)Z': (jvm, args) => {
+    'isRightMouseButton(Ljava/awt/event/MouseEvent;)Z': (jvm, obj, args) => {
       const event = args[0];
       return event && event.button === 3 ? 1 : 0;
     },

--- a/test/cfrAdditionalFeatures.test.js
+++ b/test/cfrAdditionalFeatures.test.js
@@ -177,6 +177,21 @@ LchoiceEnd:
     .end code
 .end method
 
+.method public printAsObject : (Ljava/io/PrintStream;Ljava/lang/String;)V
+    .code stack 2 locals 3
+Lobject0: aload_1
+Lobject1: aload_2
+Lobject2: invokevirtual Method java/io/PrintStream print (Ljava/lang/Object;)V
+Lobject5: return
+LobjectDone:
+        .localvariabletable
+            0 is this Lorg/benf/cfr/tests/AdditionalFeatureTest; from Lobject0 to LobjectDone
+            1 is out Ljava/io/PrintStream; from Lobject0 to LobjectDone
+            2 is value Ljava/lang/String; from Lobject0 to LobjectDone
+        .end localvariabletable
+    .end code
+.end method
+
 .method public bounds : (I)V
     .code stack 2 locals 2
 L80: iload_1
@@ -690,7 +705,7 @@ function decompileFixture(tempDir, name, source) {
 }
 
 test('CFR-JS reconstructs additional expression and declaration features', (t) => {
-  t.plan(29);
+  t.plan(30);
   withTempDir('cfr-additional-', (tempDir) => {
     const source = decompileFixture(tempDir, 'AdditionalFeatureTest', ADDITIONAL_FEATURES_JASMIN);
 
@@ -705,6 +720,8 @@ test('CFR-JS reconstructs additional expression and declaration features', (t) =
     t.match(source, /public boolean condAssignNoDup\(boolean a, boolean b\) \{\s*boolean c;\s*return b && a == \(c = b\) \|\| b && \(c = a\);\s*}/, 'frontend assignment-expression boolean condition is reconstructed');
     t.match(source, /public void guard\(boolean ok\) \{\s*if \(!ok\) \{\s*throw new RuntimeException\("bad"\);\s*}\s*}/, 'materialized boolean guard branches are reconstructed');
     t.match(source, /public void printChoice\(boolean flag, PrintStream out, String yes, String no\) \{\s*out\.print\(flag \? yes : no\);\s*}/, 'stack ternary values survive into following calls');
+    t.match(source, /public void printAsObject\(PrintStream out, String value\) \{\s*out\.print\(\(Object\) value\);\s*}/,
+      'JRE overload metadata pins a deliberately broad bytecode descriptor');
     t.match(source, /public void bounds\(int value\) \{\s*if \(\(?value < 0\)? \|\| value >= 100\) \{\s*throw new RuntimeException\("bounds"\);\s*}\s*}/, 'nested materialized boolean guards simplify to boolean expressions');
     t.match(source, /public int countDownOnce\(int n\) \{\s*int count = 0;\s*do \{\s*count = count \+ 1;\s*n--;\s*} while \(n > 0\);\s*return count;\s*}/, 'back-edge conditional loops are reconstructed as do/while');
     t.match(source, /public int sumFor\(int n\) \{\s*int sum = 0;\s*for \(int i = 0; i < n; i\+\+\) \{\s*sum = sum \+ i;\s*}\s*return sum;\s*}/, 'counting loops are reconstructed as for loops');

--- a/test/cfrAdditionalFeatures.test.js
+++ b/test/cfrAdditionalFeatures.test.js
@@ -517,6 +517,42 @@ LUncheckedReturn: return
 .end class
 `;
 
+const STATIC_INITIALIZER_JASMIN = `.version 52 0
+.class public super org/benf/cfr/tests/StaticInitializerTest
+.super java/lang/Object
+
+.field private static values [I
+
+.method public <init> : ()V
+    .code stack 1 locals 1
+Linit0: aload_0
+Linit1: invokespecial Method java/lang/Object <init> ()V
+Linit2: return
+    .end code
+.end method
+
+.method static <clinit> : ()V
+    .code stack 3 locals 1
+L0: bipush 8
+L2: newarray int
+L4: putstatic Field org/benf/cfr/tests/StaticInitializerTest values [I
+L7: iconst_0
+L8: istore_0
+L9: iload_0
+L10: bipush 8
+L12: if_icmpge L25
+L15: getstatic Field org/benf/cfr/tests/StaticInitializerTest values [I
+L18: iload_0
+L19: iload_0
+L20: iastore
+L21: iinc 0 1
+L24: goto L9
+L25: return
+    .end code
+.end method
+.end class
+`;
+
 const CONSTRUCTOR_FEATURES_JASMIN = `.version 52 0
 .class public super org/benf/cfr/tests/CtorFeatureTest
 .super org/benf/cfr/tests/BaseCtor
@@ -696,6 +732,56 @@ test('CFR-JS reconstructs additional expression and declaration features', (t) =
     t.ok(cfrInternals.isCheckedThrow('java/io/IOException'),
       'genuinely checked catches remain classified for javac reachability anchors');
   });
+});
+
+test('CFR-JS keeps ordinary class initialization inside the static initializer', (t) => {
+  withTempDir('cfr-static-initializer-', (tempDir) => {
+    const source = decompileFixture(tempDir, 'StaticInitializerTest', STATIC_INITIALIZER_JASMIN);
+
+    t.match(source, /static \{[\s\S]*?values = new int\[8\];[\s\S]*?for \(var0 = 0; var0 < 8; var0\+\+\)/,
+      'array initialization and its loop are emitted directly in static {}');
+    t.notOk(source.includes('$cfr$clinit'), 'ordinary static initialization does not gain a helper method');
+    t.end();
+  });
+});
+
+test('reference coercion recognizes widening array conversions', (t) => {
+  const base = { className: 'example/Base', superClassName: 'java/lang/Object', interfaces: [] };
+  const child = { className: 'example/Child', superClassName: 'example/Base', interfaces: [] };
+  const model = {
+    classInfo: new Map([[base.className, base], [child.className, child]]),
+    superOf: new Map([[base.className, base.superClassName], [child.className, child.superClassName]]),
+    sourceNameToInternal: new Map([['example.Base', base.className], ['example.Child', child.className]]),
+  };
+
+  t.ok(cfrInternals.isSourceReferenceTypeAssignable('example.Child', 'example.Base', model),
+    'a subclass widens to its superclass');
+  t.ok(cfrInternals.isSourceReferenceTypeAssignable('example.Child[]', 'example.Base[]', model),
+    'a subclass array widens covariantly to its superclass array');
+  t.ok(cfrInternals.isSourceReferenceTypeAssignable('example.Child[][]', 'Object[]', model),
+    'nested reference arrays widen recursively');
+  t.notOk(cfrInternals.isSourceReferenceTypeAssignable('int[]', 'Object[]', model),
+    'primitive arrays do not widen to Object arrays');
+  t.equal(
+    cfrInternals.coerceExpressionForType(
+      { code: 'children', type: 'example.Child[]', precedence: 100 },
+      'example.Base[]',
+      model,
+    ).code,
+    'children',
+    'a proven widening array conversion emits no runtime cast',
+  );
+  t.match(
+    cfrInternals.coerceExpressionForType(
+      { code: 'children', type: 'example.Child[]', precedence: 100 },
+      'example.Base[]',
+      model,
+      false,
+    ).code,
+    /^\(example\.Base\[\]\)/,
+    'overload pinning can retain an explicit descriptor cast',
+  );
+  t.end();
 });
 
 test('CFR-JS reconstructs constructor delegation calls', (t) => {

--- a/test/cfrStackOrdering.test.js
+++ b/test/cfrStackOrdering.test.js
@@ -24,6 +24,29 @@ L7: return
 .end class
 `;
 
+const STATIC_FIELD_POST_INCREMENT_ARRAY_STORE = `.version 52 0
+.class public super StaticFieldPostIncrementArrayStore
+.super java/lang/Object
+
+.field public static INDEX I
+.field public static VALUES [I
+
+.method public static fill : ()V
+    .code stack 3 locals 0
+L0: getstatic Field StaticFieldPostIncrementArrayStore VALUES [I
+L3: getstatic Field StaticFieldPostIncrementArrayStore INDEX I
+L6: dup
+L7: iconst_1
+L8: iadd
+L9: putstatic Field StaticFieldPostIncrementArrayStore INDEX I
+L12: bipush 7
+L14: iastore
+L15: return
+    .end code
+.end method
+.end class
+`;
+
 const REUSED_REFERENCE_SLOT = `.version 52 0
 .class public super ReusedReferenceSlot
 .super java/lang/Object
@@ -96,6 +119,26 @@ test('iinc snapshots operand-stack values loaded before the increment', (t) => {
       'array index uses the value captured before iinc');
     t.notOk(/param1\+\+;\s*param0\[param1\]/.test(source),
       'array store does not reread the incremented local');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  t.end();
+});
+
+test('putstatic snapshots an unqualified field index loaded before its update', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfr-static-field-order-'));
+  try {
+    const source = decompileFixture(
+      tempDir,
+      'StaticFieldPostIncrementArrayStore',
+      STATIC_FIELD_POST_INCREMENT_ARRAY_STORE,
+    );
+
+    t.match(source,
+      /int fieldTemp\$\d+ = field_INDEX;\s*field_INDEX = field_INDEX \+ 1;\s*field_VALUES\[fieldTemp\$\d+\] = 7;/,
+      'array store retains the field index captured before putstatic');
+    t.notOk(/field_INDEX = field_INDEX \+ 1;\s*field_VALUES\[field_INDEX\]/.test(source),
+      'array store does not reread the incremented static field');
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/jitCompiler.test.js
+++ b/test/jitCompiler.test.js
@@ -306,6 +306,31 @@ public class NestedGeneratedJitHarness {
   t.end();
 });
 
+test('Wasm leaves constructors and class initializers atomic', (t) => {
+  const previous = process.env.JVM_WASM_JIT;
+  process.env.JVM_WASM_JIT = '1';
+  t.teardown(() => {
+    if (previous === undefined) delete process.env.JVM_WASM_JIT;
+    else process.env.JVM_WASM_JIT = previous;
+  });
+  const jvm = new JVM({ jit: { warmupThreshold: 100 } });
+  const frame = (name) => ({ method: { name }, instructions: [{}] });
+  const method = (name) => ({
+    name,
+    attributes: [{ type: 'code', code: { codeItems: [{ instruction: 'return' }] } }],
+  });
+
+  t.equal(jvm.jit.wasmJit.prepare(frame('<init>')), null,
+    'instance constructor stays outside partial Wasm');
+  t.equal(jvm.jit.wasmJit.prepare(frame('<clinit>')), null,
+    'class initializer stays outside partial Wasm');
+  t.notOk(jvm.jit.isSupported(method('<init>')),
+    'instance constructor stays outside JavaScript JIT');
+  t.notOk(jvm.jit.isSupported(method('<clinit>')),
+    'class initializer stays outside JavaScript JIT');
+  t.end();
+});
+
 test('generated callers permanently deopt at unsupported callees', async (t) => {
   const classpath = compileJavaFixture(t, 'GeneratedTransientCallJitHarness', `
 public class GeneratedTransientCallJitHarness {

--- a/test/objectInstructionExceptions.test.js
+++ b/test/objectInstructionExceptions.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const test = require('tape');
+const Stack = require('../src/core/stack');
+const objectInstructions = require('../src/instructions/object');
+
+function frameWith(...values) {
+  const stack = new Stack();
+  values.forEach((value) => stack.push(value));
+  return { stack };
+}
+
+function isJavaNullPointerException(error) {
+  return error && error.type === 'java/lang/NullPointerException';
+}
+
+test('null field receivers throw catchable Java exceptions', (t) => {
+  const field = { arg: ['Field', 'Owner', ['value', 'I']] };
+  t.throws(
+    () => objectInstructions.getfield(frameWith(null), field, {}),
+    isJavaNullPointerException,
+    'getfield throws java/lang/NullPointerException',
+  );
+  t.throws(
+    () => objectInstructions.putfield(frameWith(null, 1), field, {}),
+    isJavaNullPointerException,
+    'putfield throws java/lang/NullPointerException',
+  );
+  t.end();
+});

--- a/test/saveState.test.js
+++ b/test/saveState.test.js
@@ -52,6 +52,7 @@ test('portable JVM save states preserve heap identity and deterministic executio
   shared.fields.self = shared;
   shared.fields.array = array;
   shared.fields.pixels = new Uint8Array([1, 2, 3, 255]);
+  shared.fields.boxedString = new String('saved'); // eslint-disable-line no-new-wrappers
   shared.fields.raf = raf;
   classData.staticFields.set('root:Ljava/lang/Object;', shared);
 
@@ -86,6 +87,8 @@ test('portable JVM save states preserve heap identity and deterministic executio
   t.equal(restoredRoot.fields.array[1], 7n, 'long/BigInt values survive');
   t.deepEqual(Array.from(restoredRoot.fields.pixels), [1, 2, 3, 255],
     'typed arrays survive without object-graph element traversal');
+  t.equal(String(restoredRoot.fields.boxedString), 'saved',
+    'boxed strings survive thread-reference restoration');
   t.equal(typeof restoredRoot.fields.raf.fileHandle.read, 'function',
     'portable file metadata reopens its host handle');
   t.equal(restored.threads[0].callStack.peek().locals[1], restoredRoot,

--- a/test/stringBuilderJre.test.js
+++ b/test/stringBuilderJre.test.js
@@ -1,0 +1,18 @@
+const test = require('tape');
+const { JVM } = require('../src/core/jvm');
+
+test('StringBuilder.append(CharSequence) appends and returns the receiver', (t) => {
+  const jvm = new JVM({ verbose: false });
+  const append = jvm._jreFindMethod(
+    'java/lang/StringBuilder',
+    'append',
+    '(Ljava/lang/CharSequence;)Ljava/lang/StringBuilder;',
+  );
+  const builder = { type: 'java/lang/StringBuilder', value: 'Deko ' };
+  const sequence = new String('Bloko');
+  sequence.type = 'java/lang/String';
+
+  t.equal(append(jvm, builder, [sequence]), builder, 'returns the receiver');
+  t.equal(builder.value, 'Deko Bloko', 'appends the CharSequence contents');
+  t.end();
+});

--- a/test/swingUtilities.test.js
+++ b/test/swingUtilities.test.js
@@ -1,0 +1,17 @@
+const test = require('tape');
+const { JVM } = require('../src/core/jvm');
+
+test('SwingUtilities.isRightMouseButton uses static JRE calling convention', (t) => {
+  const jvm = new JVM({ verbose: false });
+  const method = jvm._jreFindMethod(
+    'javax/swing/SwingUtilities',
+    'isRightMouseButton',
+    '(Ljava/awt/event/MouseEvent;)Z',
+  );
+
+  t.equal(method(jvm, null, [{ type: 'java/awt/event/MouseEvent', button: 1 }]), 0,
+    'left mouse button is false');
+  t.equal(method(jvm, null, [{ type: 'java/awt/event/MouseEvent', button: 3 }]), 1,
+    'right mouse button is true');
+  t.end();
+});


### PR DESCRIPTION
## What changed

- Preserve static-field stack snapshots and Java overload selection in emitted source.
- Emit ordinary class initialization directly and recognize safe reference-array widening.
- Keep constructors and class initializers out of partial JIT tiers.
- Make null field accesses catchable Java exceptions.
- Repair save-state and small JRE compatibility gaps exposed by the AWT replay.

## Why

Decompiler-compiled Dekobloko reached the game UI but intermittently rendered corrupt text and frames. The source emitter could reread a static index after incrementing it and could let javac select a different overload. Partial compilation and runtime shim gaps exposed additional parity failures.

## Validation

The focused Node test command passed all 189 checks across decompiler emission, stack ordering, JIT/Wasm, JVM exceptions, save states, and JRE shims.

## Summary by Sourcery

Improve decompiled Java runtime parity, JIT behavior, and JRE shims to match JVM semantics observed in game and UI workloads.

Bug Fixes:
- Preserve operand-stack snapshots for static fields so post-increment array stores and similar patterns keep original indices.
- Stabilize Java overload resolution by modeling widening reference and array conversions and consulting class/JRE metadata when emitting calls.
- Keep ordinary class initialization inside static initializers instead of helper methods, avoiding exposure of partially initialized classes.
- Exclude constructors and class initializers from partial JIT tiers in both JS and Wasm backends to keep object and class setup atomic.
- Make instance field access on null throw structured java/lang/NullPointerException objects so they are catchable by Java code.
- Ensure save-state serialization correctly preserves boxed String instances without traversing or corrupting them.
- Fix StringBuilder.append(CharSequence) and SwingUtilities.isRightMouseButton JRE shims to follow correct signatures and calling conventions.

Enhancements:
- Extend the exception/typing model with source-name-to-internal mappings and widening reference checks to better guide expression coercion.
- Expose additional internal helpers for reference assignability and coercion to support richer tests and future decompiler improvements.

Tests:
- Add decompiler tests for overload pinning, widening array conversions, and keeping normal class initialization within static blocks.
- Add stack-ordering tests to verify static field snapshots around putstatic are preserved in emitted source.
- Add JIT tests ensuring constructors and class initializers are never partially compiled in JS or Wasm JITs.
- Add focused tests for null field access exceptions, StringBuilder CharSequence append behavior, SwingUtilities mouse button detection, and boxed String save-state handling.