### PR TITLE
Preserve duplicated array identity through stores

### DIFF
--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -2599,8 +2599,15 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
 
     const storeIndex = parseStoreIndex(op, instruction.arg);
     if (storeIndex) {
-      const value = renderStoreExpression(pop(stack));
-      lines.push(localState.store(storeIndex.index, storeIndex.type, value, codeItem.pc));
+      const value = pop(stack);
+      // A dup can leave the freshly allocated array live for a field/array
+      // store after this local store.  Materialize the shared expression now
+      // so every consumer observes the one JVM allocation.
+      if (stack.includes(value) && value.newArraySpill && /^new\b/.test(value.code)) {
+        materializeNewArraySpill(value, lines, localState);
+      }
+      const renderedValue = renderStoreExpression(value);
+      lines.push(localState.store(storeIndex.index, storeIndex.type, renderedValue, codeItem.pc));
       continue;
     }
 

--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -2680,7 +2680,7 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       }
       const value = materializeDuplicatedValue(top, lines, localState);
       stack[stack.length - 1] = value;
-      stack.push({ ...value });
+      stack.push(duplicateStackExpression(value));
       continue;
     }
     if (op === 'dup_x1') {
@@ -2696,12 +2696,12 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       if (isCategory2(raw2)) {
         const value2 = materializeDuplicatedValue(raw2, lines, localState);
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push({ ...value1 }, value2, value1);
+        stack.push(duplicateStackExpression(value1), value2, value1);
       } else {
         const value3 = materializeDuplicatedValue(pop(stack), lines, localState);
         const value2 = materializeDuplicatedValue(raw2, lines, localState);
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push({ ...value1 }, value3, value2, value1);
+        stack.push(duplicateStackExpression(value1), value3, value2, value1);
       }
       continue;
     }
@@ -2709,11 +2709,11 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       const raw1 = pop(stack);
       if (isCategory2(raw1)) {
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push(value1, { ...value1 });
+        stack.push(value1, duplicateStackExpression(value1));
       } else {
         const value2 = materializeDuplicatedValue(pop(stack), lines, localState);
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push(value2, value1, { ...value2 }, { ...value1 });
+        stack.push(value2, value1, duplicateStackExpression(value2), duplicateStackExpression(value1));
       }
       continue;
     }
@@ -2722,13 +2722,13 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       if (isCategory2(raw1)) {
         const value2 = materializeDuplicatedValue(pop(stack), lines, localState);
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push({ ...value1 }, value2, value1);
+        stack.push(duplicateStackExpression(value1), value2, value1);
       } else {
         const raw2 = pop(stack);
         const value3 = materializeDuplicatedValue(pop(stack), lines, localState);
         const value2 = materializeDuplicatedValue(raw2, lines, localState);
         const value1 = materializeDuplicatedValue(raw1, lines, localState);
-        stack.push({ ...value2 }, { ...value1 }, value3, value2, value1);
+        stack.push(duplicateStackExpression(value2), duplicateStackExpression(value1), value3, value2, value1);
       }
       continue;
     }
@@ -2739,12 +2739,12 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
         if (isCategory2(raw2)) {
           const value2 = materializeDuplicatedValue(raw2, lines, localState);
           const value1 = materializeDuplicatedValue(raw1, lines, localState);
-          stack.push({ ...value1 }, value2, value1);
+          stack.push(duplicateStackExpression(value1), value2, value1);
         } else {
           const value3 = materializeDuplicatedValue(pop(stack), lines, localState);
           const value2 = materializeDuplicatedValue(raw2, lines, localState);
           const value1 = materializeDuplicatedValue(raw1, lines, localState);
-          stack.push({ ...value1 }, value3, value2, value1);
+          stack.push(duplicateStackExpression(value1), value3, value2, value1);
         }
       } else {
         const raw2 = pop(stack);
@@ -2753,13 +2753,13 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
           const value3 = materializeDuplicatedValue(raw3, lines, localState);
           const value2 = materializeDuplicatedValue(raw2, lines, localState);
           const value1 = materializeDuplicatedValue(raw1, lines, localState);
-          stack.push({ ...value2 }, { ...value1 }, value3, value2, value1);
+          stack.push(duplicateStackExpression(value2), duplicateStackExpression(value1), value3, value2, value1);
         } else {
           const value4 = materializeDuplicatedValue(pop(stack), lines, localState);
           const value3 = materializeDuplicatedValue(raw3, lines, localState);
           const value2 = materializeDuplicatedValue(raw2, lines, localState);
           const value1 = materializeDuplicatedValue(raw1, lines, localState);
-          stack.push({ ...value2 }, { ...value1 }, value4, value3, value2, value1);
+          stack.push(duplicateStackExpression(value2), duplicateStackExpression(value1), value4, value3, value2, value1);
         }
       }
       continue;
@@ -2847,7 +2847,7 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       continue;
     }
     if (ARRAY_STORE_TYPES[op]) {
-      const value = pop(stack);
+      let value = pop(stack);
       const index = pop(stack);
       let array = pop(stack);
       const arrayType = op === 'aastore' ? 'Object[]' : `${ARRAY_STORE_TYPES[op]}[]`;
@@ -2859,16 +2859,18 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
         if (refined === arrayType) array = { ...array, type: refined };
         else array = coerceExpressionForType(array, arrayType);
       }
+      // A dup_x2 can leave the freshly allocated value below this outer-array
+      // store for a following astore.  Materialize it once and mutate the
+      // shared expression so both consumers retain JVM reference identity.
+      if (stack.includes(value) && value.newArraySpill && /^new\b/.test(value.code)) {
+        materializeNewArraySpill(value, lines, localState);
+      }
+      value = renderStoreExpression(value);
       if (array.arrayLiteral && /^\d+$/.test(index.code)) {
         array.arrayLiteral.elements.set(Number(index.code), value);
       } else {
         if (array.newArraySpill && /^new\b/.test(array.code)) {
-          // Materialize the fresh array into a synthetic local before storing;
-          // the shared expr object makes every later reference use the local.
-          const name = localState.nextSyntheticName();
-          lines.push(`${array.type} ${name} = ${array.code};`);
-          array.code = name;
-          array.newArraySpill = undefined;
+          materializeNewArraySpill(array, lines, localState);
         }
         const elementType = op === 'bastore' && array.type === 'boolean[]'
           ? 'boolean'
@@ -3073,7 +3075,7 @@ function formatCallArguments(ref, descriptor, args, exceptionModel) {
       return `(${simplifyType(target)}) null`;
     }
     const value = coerceExpressionForType(
-      arg,
+      renderStoreExpression(arg),
       target || arg.type,
       exceptionModel,
       !mustPinReferenceOverload,
@@ -5966,6 +5968,24 @@ function materializeDuplicatedValue(value, lines, localState) {
   const name = localState.nextSyntheticName('dupTemp');
   lines.push(`${simplifyType(rendered.type)} ${name} = ${rendered.code};`);
   return expr(name, value.type, 100);
+}
+
+// Array construction metadata is intentionally mutable while dup-based fills
+// are reconstructed.  Every duplicated stack slot must therefore retain the
+// same expression object; a shallow clone shares the element map but not later
+// code/spill updates, which can emit a second allocation for one JVM value.
+function duplicateStackExpression(value) {
+  if (value && (value.newArraySpill || value.arrayLiteral)) return value;
+  return { ...value };
+}
+
+function materializeNewArraySpill(value, lines, localState) {
+  const name = localState.nextSyntheticName();
+  lines.push(`${value.type} ${name} = ${value.code};`);
+  value.code = name;
+  value.newArraySpill = undefined;
+  value.arrayLiteral = undefined;
+  return value;
 }
 
 // Before a field write, freeze any live stack expression that reads the same

--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -2694,7 +2694,7 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
       const raw1 = pop(stack);
       const value2 = materializeDuplicatedValue(pop(stack), lines, localState);
       const value1 = materializeDuplicatedValue(raw1, lines, localState);
-      stack.push({ ...value1 }, value2, value1);
+      stack.push(duplicateStackExpression(value1), value2, value1);
       continue;
     }
     if (op === 'dup_x2') {
@@ -2896,7 +2896,11 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
     }
     if (op === 'putstatic') {
       const ref = parseMemberRef(instruction.arg);
-      const value = coerceExpressionForType(renderStoreExpression(pop(stack)), descriptorToJavaType(ref.descriptor));
+      const rawValue = pop(stack);
+      if (stack.includes(rawValue) && rawValue.newArraySpill && /^new\b/.test(rawValue.code)) {
+        materializeNewArraySpill(rawValue, lines, localState);
+      }
+      const value = coerceExpressionForType(renderStoreExpression(rawValue), descriptorToJavaType(ref.descriptor));
       // A live stack value that reads this same field (e.g. the old value dup_x1'd
       // below the store target in a post-increment `f[x++]=v` idiom) would re-read
       // the *mutated* field after this assignment. Spill such reads to a temp first.
@@ -2914,7 +2918,11 @@ function decompileLinearCodeItems(codeItems, method, cls, localState, options = 
     }
     if (op === 'putfield') {
       const ref = parseMemberRef(instruction.arg);
-      const value = coerceExpressionForType(renderStoreExpression(pop(stack)), descriptorToJavaType(ref.descriptor));
+      const rawValue = pop(stack);
+      if (stack.includes(rawValue) && rawValue.newArraySpill && /^new\b/.test(rawValue.code)) {
+        materializeNewArraySpill(rawValue, lines, localState);
+      }
+      const value = coerceExpressionForType(renderStoreExpression(rawValue), descriptorToJavaType(ref.descriptor));
       const owner = coerceExpressionForType(pop(stack), javaTypeFromInternalName(ref.owner));
       // Spill any live stack value that reads this field before mutating it, so a
       // post-increment index (`this.r[this.n++] = v`) keeps its pre-increment value.
@@ -5982,7 +5990,7 @@ function materializeDuplicatedValue(value, lines, localState) {
 // same expression object; a shallow clone shares the element map but not later
 // code/spill updates, which can emit a second allocation for one JVM value.
 function duplicateStackExpression(value) {
-  if (value && (value.newArraySpill || value.arrayLiteral)) return value;
+  if (!value || value.newArraySpill || value.arrayLiteral) return value;
   return { ...value };
 }
 

--- a/test/cfrDupSideEffects.test.js
+++ b/test/cfrDupSideEffects.test.js
@@ -63,6 +63,75 @@ L11: areturn
 .end class
 `;
 
+const DUP_ARRAY_PATTERNS = `.version 52 0
+.class public super DupArray
+.super java/lang/Object
+
+.method public static native consume : ([Ljava/lang/String;)V
+.end method
+
+.method public static shareDynamic : ([[BI)[B
+    .code stack 4 locals 3
+L0: aload_0
+L1: iconst_0
+L2: iload_1
+L3: newarray byte
+L5: dup_x2
+L6: aastore
+L7: astore_2
+L8: aload_2
+L9: iconst_0
+L10: bipush 7
+L12: bastore
+L13: aload_2
+L14: areturn
+    .end code
+.end method
+
+.method public static passReferenceLiteral : ()V
+    .code stack 4 locals 0
+L20: iconst_2
+L21: anewarray java/lang/String
+L24: dup
+L25: iconst_0
+L26: ldc "left"
+L28: aastore
+L29: dup
+L30: iconst_1
+L31: ldc "right"
+L33: aastore
+L34: invokestatic Method DupArray consume ([Ljava/lang/String;)V
+L37: return
+    .end code
+.end method
+
+.method public static nestedPrimitiveLiteral : ()[[I
+    .code stack 6 locals 0
+L40: iconst_1
+L41: anewarray [I
+L44: dup
+L45: iconst_0
+L46: iconst_3
+L47: newarray int
+L49: dup
+L50: iconst_0
+L51: iconst_0
+L52: iastore
+L53: dup
+L54: iconst_1
+L55: ldc 16777215
+L57: iastore
+L58: dup
+L59: iconst_2
+L60: iconst_1
+L61: iastore
+L62: aastore
+L63: areturn
+    .end code
+.end method
+.end class
+`;
+
 function decompileFixture(tempDir, name, source) {
   const classFile = path.join(tempDir, `${name}.class`);
   assembleJasminSource(source, classFile);
@@ -95,6 +164,34 @@ test('new/dup/<init> constructor pattern still allocates exactly once', (t) => {
     const source = decompileFixture(tempDir, 'DupNew', DUP_CONSTRUCTOR_PATTERN);
     const allocations = (source.match(/new Object\(\)/g) || []).length;
     t.equal(allocations, 1, 'constructed object is allocated exactly once');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  t.end();
+});
+
+test('dup array patterns preserve allocation identity and recorded elements', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfr-dup-array-'));
+  try {
+    const source = decompileFixture(tempDir, 'DupArray', DUP_ARRAY_PATTERNS);
+    const dynamicMethod = /public static byte\[\] shareDynamic[\s\S]*?\n    }/.exec(source);
+    t.ok(dynamicMethod, 'dynamic shared-array method is emitted');
+    const dynamicSource = dynamicMethod ? dynamicMethod[0] : source;
+    t.equal((dynamicSource.match(/new byte\[param1\]/g) || []).length, 1,
+      'dynamic byte array is allocated exactly once');
+    const spill = /byte\[\] (\w+\$\d+) = new byte\[param1\];/.exec(dynamicSource);
+    t.ok(spill, 'dynamic allocation is spilled to a shared local');
+    if (spill) {
+      const escaped = spill[1].replace(/\$/g, '\\$');
+      t.match(dynamicSource, new RegExp(`param0\\[0\\] = ${escaped};`),
+        'outer array stores the shared allocation');
+      t.match(dynamicSource, new RegExp(`byte\\[\\] var2 = ${escaped};`),
+        'local stores the same allocation');
+    }
+    t.match(source, /DupArray\.consume\(new String\[\]\{"left", "right"\}\);/,
+      'inline reference-array call retains its elements');
+    t.match(source, /return new int\[\]\[\]\{new int\[\]\{0, 16777215, 1\}\};/,
+      'primitive inner-array values survive the outer array store');
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/cfrDupSideEffects.test.js
+++ b/test/cfrDupSideEffects.test.js
@@ -87,6 +87,17 @@ L12: areturn
     .end code
 .end method
 
+.method public shareFieldAndReturn : (I)[I
+    .code stack 3 locals 2
+L20: aload_0
+L21: iload_1
+L22: newarray int
+L24: dup_x1
+L25: putfield Field DupArray values [I
+L28: areturn
+    .end code
+.end method
+
 .method public static shareDynamic : ([[BI)[B
     .code stack 4 locals 3
 L0: aload_0
@@ -218,6 +229,20 @@ test('dup array patterns preserve allocation identity and recorded elements', (t
         'local stores the shared int array');
       t.match(localAndFieldSource, new RegExp(`field_values = ${escaped};`),
         'field stores the shared int array');
+    }
+    const fieldAndReturnMethod = /public int\[\] shareFieldAndReturn[\s\S]*?\n    }/.exec(source);
+    t.ok(fieldAndReturnMethod, 'dup_x1 field-and-return shared-array method is emitted');
+    const fieldAndReturnSource = fieldAndReturnMethod ? fieldAndReturnMethod[0] : source;
+    t.equal((fieldAndReturnSource.match(/new int\[/g) || []).length, 1,
+      'dup_x1 preserves one allocation for the field and return value');
+    const returnSpill = /int\[\] (\w+\$\d+) = new int\[param0\];/.exec(fieldAndReturnSource);
+    t.ok(returnSpill, 'dup_x1 allocation is spilled once');
+    if (returnSpill) {
+      const escaped = returnSpill[1].replace(/\$/g, '\\$');
+      t.match(fieldAndReturnSource, new RegExp(`field_values = ${escaped};`),
+        'field stores the shared dup_x1 array');
+      t.match(fieldAndReturnSource, new RegExp(`return ${escaped};`),
+        'method returns the shared dup_x1 array');
     }
     t.match(source, /DupArray\.consume\(new String\[\]\{"left", "right"\}\);/,
       'inline reference-array call retains its elements');

--- a/test/cfrDupSideEffects.test.js
+++ b/test/cfrDupSideEffects.test.js
@@ -70,6 +70,23 @@ const DUP_ARRAY_PATTERNS = `.version 52 0
 .method public static native consume : ([Ljava/lang/String;)V
 .end method
 
+.field public values [I
+
+.method public shareLocalAndField : (I)[I
+    .code stack 3 locals 3
+L0: aload_0
+L1: iload_1
+L2: iconst_2
+L3: imul
+L4: newarray int
+L6: dup
+L7: astore_2
+L8: putfield Field DupArray values [I
+L11: aload_2
+L12: areturn
+    .end code
+.end method
+
 .method public static shareDynamic : ([[BI)[B
     .code stack 4 locals 3
 L0: aload_0
@@ -187,6 +204,20 @@ test('dup array patterns preserve allocation identity and recorded elements', (t
         'outer array stores the shared allocation');
       t.match(dynamicSource, new RegExp(`byte\\[\\] var2 = ${escaped};`),
         'local stores the same allocation');
+    }
+    const localAndFieldMethod = /public int\[\] shareLocalAndField[\s\S]*?\n    }/.exec(source);
+    t.ok(localAndFieldMethod, 'local-and-field shared-array method is emitted');
+    const localAndFieldSource = localAndFieldMethod ? localAndFieldMethod[0] : source;
+    t.equal((localAndFieldSource.match(/new int\[/g) || []).length, 1,
+      'local and field share one int-array allocation');
+    const fieldSpill = /int\[\] (\w+\$\d+) = new int\[param0 \* 2\];/.exec(localAndFieldSource);
+    t.ok(fieldSpill, 'local-and-field allocation is spilled once');
+    if (fieldSpill) {
+      const escaped = fieldSpill[1].replace(/\$/g, '\\$');
+      t.match(localAndFieldSource, new RegExp(`int\\[\\] var2 = ${escaped};`),
+        'local stores the shared int array');
+      t.match(localAndFieldSource, new RegExp(`field_values = ${escaped};`),
+        'field stores the shared int array');
     }
     t.match(source, /DupArray\.consume\(new String\[\]\{"left", "right"\}\);/,
       'inline reference-array call retains its elements');


### PR DESCRIPTION
Fixes Kreijstal/dekobloko-work#20.
Fixes Kreijstal/dekobloko-work#22.

## What changed

- Preserve shared array-construction expression identity across all dup-family stack operations.
- Spill a dynamic array value once when an outer array store and a later local store consume the same JVM reference.
- Preserve the same allocation through `newarray; dup; astore; putfield`, rather than rendering a second allocation for the field.
- Render completed array literals before call-argument coercion and before storing them into outer literals.
- Add bytecode-level regressions for the exact glyph-mask, rotation-buffer, inline reference-array, and nested primitive-array shapes.

## Root cause

The decompiler treated duplicated operand-stack entries as independently renderable source expressions. A later spill or local store could consume one entry without rewriting the still-live duplicate, so one JVM `newarray` became two Java allocations. Issue #20 filled a local glyph mask while the font table retained a zero-filled allocation; issue #22 rotated into a local buffer while the active-shape field retained a different zero-filled allocation.

## Validation

- CFR-JS suite: 144/144 passed.
- Focused duplicated-array suite: 18/18 passed.
- Real Dekobloko `ge.class` emits one shared byte-array allocation for the glyph mask.
- Real Dekobloko `lk.class` emits one shared int-array allocation for the rotation buffer and `field_B`.
- All 343 Dekobloko sources decompiled and compiled into 343 classes with javac source/target 7 before the issue #22 follow-up; a fresh whole-game regeneration is tracked separately.
- The issue #20 replay completed all 1,009 event records under real-time Xvfb execution without the accelerated-run image-ordering error; this environment's offscreen framebuffer remained black, so the runtime visual result was not used as proof.

## Summary by Sourcery

Preserve identity of duplicated array constructions across stack operations so decompiled code reflects a single JVM allocation, and add regression coverage for these dup-based array patterns.

Bug Fixes:
- Ensure duplicated array stack values share a single allocation when stored into locals, fields, outer arrays, or returned, preventing extra array constructions in the decompiled output.
- Fix handling of dup/dup_x* stack operations so cloned expressions retain shared mutable array-construction metadata instead of diverging into separate allocations.
- Correct array store, putfield/putstatic, and call-argument rendering to materialize shared new-array spills once and reuse them across all consumers.

Enhancements:
- Factor out utilities to duplicate stack expressions and materialize new-array spills, improving clarity and reuse in the decompiler’s stack-handling logic.

Tests:
- Add Jasmin-based regression tests covering shared local/field arrays, dynamic array sharing, inline reference-array literals, and nested primitive-array literals to lock in correct array identity and contents.
