### PR TITLE
Preserve live post-terminal goto entries

### DIFF
--- a/src/passes/peepholeClean.js
+++ b/src/passes/peepholeClean.js
@@ -2100,7 +2100,8 @@ function removeDeadGotoIslandsAfterTerminals(code, context = null) {
     const instruction = codeItems[i] && codeItems[i].instruction;
     if (!isTerminalOpcode(opcodeMnemonic(instruction))) continue;
 
-    let j = nextInstructionIndex(codeItems, i + 1);
+    let scanStart = i + 1;
+    let j = nextInstructionIndex(codeItems, scanStart);
     while (j != null) {
       // nextInstructionIndex deliberately skips label-only and nop entries.
       // A referenced label in that skipped range is a live alternate entry,
@@ -2108,7 +2109,7 @@ function removeDeadGotoIslandsAfterTerminals(code, context = null) {
       // changes the branch target's continuation (and can disconnect a whole
       // region, as in Dekobloko's flat-triangle rasterizer).
       let hasLiveEntry = false;
-      for (let k = i + 1; k <= j; k += 1) {
+      for (let k = scanStart; k <= j; k += 1) {
         const label = trimLabel(codeItems[k] && codeItems[k].labelDef);
         if (label && ((refCounts.get(label) || 0) > 0 || isLabelProtected(code, label))) {
           hasLiveEntry = true;
@@ -2120,9 +2121,13 @@ function removeDeadGotoIslandsAfterTerminals(code, context = null) {
       if (op !== 'goto' && op !== 'goto_w') break;
       const target = trimLabel(getBranchArg(codeItems[j].instruction));
       if (target) refCounts.set(target, Math.max(0, (refCounts.get(target) || 0) - 1));
+      const previousLength = codeItems.length;
       removeInstructionOnly(codeItems, j);
       removed += 1;
-      j = nextInstructionIndex(codeItems, j + 1);
+      // An unlabelled item is spliced, so the next unscanned entry shifts into
+      // j. A labelled item stays in place with only its instruction removed.
+      scanStart = codeItems.length < previousLength ? j : j + 1;
+      j = nextInstructionIndex(codeItems, scanStart);
     }
   }
 

--- a/src/passes/peepholeClean.js
+++ b/src/passes/peepholeClean.js
@@ -2102,8 +2102,20 @@ function removeDeadGotoIslandsAfterTerminals(code, context = null) {
 
     let j = nextInstructionIndex(codeItems, i + 1);
     while (j != null) {
-      const label = trimLabel(codeItems[j] && codeItems[j].labelDef);
-      if (label && ((refCounts.get(label) || 0) > 0 || isLabelProtected(code, label))) break;
+      // nextInstructionIndex deliberately skips label-only and nop entries.
+      // A referenced label in that skipped range is a live alternate entry,
+      // so the following goto is not a dead post-terminal island: removing it
+      // changes the branch target's continuation (and can disconnect a whole
+      // region, as in Dekobloko's flat-triangle rasterizer).
+      let hasLiveEntry = false;
+      for (let k = i + 1; k <= j; k += 1) {
+        const label = trimLabel(codeItems[k] && codeItems[k].labelDef);
+        if (label && ((refCounts.get(label) || 0) > 0 || isLabelProtected(code, label))) {
+          hasLiveEntry = true;
+          break;
+        }
+      }
+      if (hasLiveEntry) break;
       const op = opcodeMnemonic(codeItems[j] && codeItems[j].instruction);
       if (op !== 'goto' && op !== 'goto_w') break;
       const target = trimLabel(getBranchArg(codeItems[j].instruction));

--- a/test/peepholeClean.test.js
+++ b/test/peepholeClean.test.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const test = require('tape');
-const { runPeepholeClean, normalizeDupStoreCompareBranches } = require('../src/passes/peepholeClean');
+const {
+  runPeepholeClean,
+  normalizeDupStoreCompareBranches,
+} = require('../src/passes/peepholeClean');
 
 function astWith(codeItems, exceptionTable = []) {
   return {
@@ -262,6 +265,32 @@ test('peephole clean removes dead goto islands after terminals', (t) => {
   t.equal(result.details.deadGotoIslands, 2);
   t.equal(code(ast).codeItems.some((item) => item.instruction && item.instruction.arg === 'LdeadBody'), false);
   t.equal(code(ast).codeItems.some((item) => item.instruction && item.instruction.arg === 'LdeadBody2'), false);
+  t.end();
+});
+
+test('peephole clean preserves a goto after a referenced label-only entry', (t) => {
+  const ast = astWith([
+    { instruction: 'iload_1' },
+    { instruction: { op: 'ifeq', arg: 'Llive' } },
+    { instruction: 'iload_2' },
+    { instruction: { op: 'ifeq', arg: 'Llive' } },
+    { instruction: 'return' },
+    { labelDef: 'Llive:', instruction: 'nop' },
+    { instruction: 'nop' },
+    { instruction: { op: 'goto', arg: 'Lbody' } },
+    { instruction: 'return' },
+    { labelDef: 'Lbody:', instruction: 'iconst_0' },
+    { instruction: 'pop' },
+    { instruction: 'return' },
+  ]);
+
+  const result = runPeepholeClean(ast, { removeDeadGotoIslands: true });
+
+  t.equal(result.details.deadGotoIslands, 0,
+    'the referenced entry prevents post-terminal island deletion');
+  t.ok(code(ast).codeItems.some((item) =>
+    item.instruction && item.instruction.op === 'goto' && item.instruction.arg === 'Lbody'),
+  'the live entry still jumps over the intervening return');
   t.end();
 });
 

--- a/test/peepholeClean.test.js
+++ b/test/peepholeClean.test.js
@@ -294,6 +294,26 @@ test('peephole clean preserves a goto after a referenced label-only entry', (t) 
   t.end();
 });
 
+test('peephole clean removes consecutive unlabelled post-terminal gotos', (t) => {
+  const ast = astWith([
+    { instruction: 'return' },
+    { instruction: { op: 'goto', arg: 'Ldead1' } },
+    { instruction: { op: 'goto', arg: 'Ldead2' } },
+    { labelDef: 'Ldead1:', instruction: 'iconst_1' },
+    { instruction: 'pop' },
+    { labelDef: 'Ldead2:', instruction: 'return' },
+  ]);
+
+  const result = runPeepholeClean(ast, { removeDeadGotoIslands: true });
+
+  t.equal(result.details.deadGotoIslands, 2,
+    'splicing the first goto does not skip the next shifted entry');
+  t.notOk(code(ast).codeItems.some((item) =>
+    item.instruction && (item.instruction.op === 'goto' || item.instruction.op === 'goto_w')),
+  'both dead gotos are removed');
+  t.end();
+});
+
 test('peephole clean can clone conditional shared loop tail for one predecessor', (t) => {
   const ast = astWith([
     { labelDef: 'Lhead:', instruction: 'aload_1' },


### PR DESCRIPTION
Fixes Kreijstal/dekobloko-work#23.

## What changed

- Preserve post-terminal `goto` instructions when a referenced or exception-protected label occurs between the terminal and the jump.
- Add a regression for a shared label-only entry that must jump over an intervening return.

## Root cause

`removeDeadGotoIslandsAfterTerminals` used `nextInstructionIndex`, which skips label-only and `nop` entries. It checked only the label attached to the following instruction, so it could miss a referenced label in the skipped range and delete that label's live continuation.

In Dekobloko's flat-triangle rasterizer, several clipping branches target such a label after a `return`. The missed label precedes a `goto` into the scan-conversion body. Deleting that jump redirects every accepted triangle to another return; the final unreachable-code sweep then removes all six scanline calls.

## Impact

The transformed and decompiled `ib.a(...)` now retains its complete flat-color triangle rasterizer, restoring the solid faces of the opening Jagex logo.

## Validation

- `node test/peepholeClean.test.js`: 166/166 passed.
- `npm test`: 4,574/4,574 passed.
- Full experimental-DCE Dekobloko pipeline: 343/343 classes processed with no passthrough failures.
- Repository-faithful decompile/compile using `dekobloko-stubs.jar`: 343 sources compiled into 343 classes.
- Generated `ib.java` retains all six `cf.a(...)` scanline calls and has no empty `decompiledRegionSelector0` shell.
- Reflection differential: 2,000 deterministic nondegenerate triangles produced pixel-identical original and decompiled/recompiled framebuffers; 1,053 triangles changed 743,079 pixels.

## Summary by Sourcery

Ensure peephole cleanup preserves live post-terminal goto entries while still removing truly dead goto islands.

Bug Fixes:
- Fix removal of post-terminal goto instructions when a referenced or exception-protected label lies between the terminal and the goto, preventing disconnection of live control-flow regions.

Tests:
- Add regression tests to verify that post-terminal gotos are preserved when preceded by a referenced label-only entry and that consecutive unlabelled post-terminal gotos are fully removed.