### PR TITLE
Optimize generated JVM execution and continuous browser audio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
         java-version: [11, 17]
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Kreijstal/java-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/Kreijstal/java-tools/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Node.js](https://img.shields.io/badge/node.js-18.x%20%7C%2020.x-green.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node.js-20.x-green.svg)](https://nodejs.org/)
 [![Java](https://img.shields.io/badge/java-11%20%7C%2017-orange.svg)](https://adoptopenjdk.net/)
 
 A comprehensive toolkit for Java bytecode analysis, manipulation, and execution. This project provides advanced tools for working with Java `.class` files, including a custom JVM implementation, web-based debugging interface, and extensive bytecode analysis capabilities.

--- a/docs/affine-sprite-raster-jit.md
+++ b/docs/affine-sprite-raster-jit.md
@@ -1,0 +1,150 @@
+# Structurally verified affine sprite raster JIT
+
+## Finding
+
+Firefox phase-local timing of moving Dekobloko gameplay identified a nested
+column-oriented affine sprite/mask rasterizer as a dominant generated guest
+body. Its structured continuation had 283 bytecode instructions, 33 locals,
+21 spilled locals, two loops, and two calls to the same integer-division
+helper. The continuation repeatedly materialized this state while the outer UI
+renderer called the rasterizer more than 20,000 times per second.
+
+The browser canvas upload was not the limiting stage. In the same sessions,
+upload averaged about 0.95 ms per presented image. Long synchronous guest
+rendering intervals also prevented the guest audio producer from refilling its
+WebAudio queue, coupling low gameplay FPS to audible music gaps.
+
+## Optimization
+
+`HandwrittenAffineSpriteRaster` replaces the verified guest body with one
+positional JavaScript kernel:
+
+- Selection uses the complete descriptor, verified CFG and stack depths,
+  repeated call/field relationships, and identity-canonicalized bytecode
+  fingerprints.
+- No guest class, method, or field name participates in recognition.
+- Both the original classfile and decompile-then-`javac` layouts are accepted
+  as independently audited fingerprints.
+- The two `(III)I` calls must resolve to the same verified helper shape.
+- Initialized static locations and instance-field slots are bound once while
+  their current values remain live.
+- A class/debugger guard and complete array/layout preflight run before the
+  first destination write. Rejected entries execute the canonical JVM method.
+- `JVM_DISABLE_AFFINE_SPRITE_RASTER=1` or JIT option
+  `affineSpriteRaster: false` provides a same-bundle differential control.
+- Runtime counters expose successful runs and guarded fallbacks.
+
+The structured SSA caller feeds the 12 operands positionally, avoiding generic
+call dispatch, a child `Frame`, operand-stack materialization, and generator
+continuations inside the raster body.
+
+## Correctness
+
+The focused JIT suite contains a deterministic differential over 200 moving,
+clipped, masked, dimmed, and destination-blended invocations. It compares
+every destination pixel against an independently expressed Java-arithmetic
+reference. Separate cases verify floor-division behavior and that source or
+destination rejection happens before any write.
+
+Command:
+
+```text
+timeout 90s node node_modules/tape/bin/tape test/jitCompiler.test.js
+```
+
+Result on 2026-07-28: 746 tests passed.
+
+Both production class layouts were also loaded through the JVM and passed the
+complete matcher:
+
+| Layout | Caller fingerprint | Helper fingerprint | Suite fingerprint |
+| --- | ---: | ---: | ---: |
+| Original classfile | 1773827786 | 1778623157 | 2237033000 |
+| Decompile + `javac` | 1163529563 | 182681963 | 1400128061 |
+
+## Firefox measurement
+
+The probe follows the real full-mode path: login, asset/audio startup, Stamina
+selection, stage intro, Space to start, ten-second gameplay warmup, and a
+15-second moving-gameplay window. Generated-method timing is disabled during
+the measurement. It records presented images, WebAudio diagnostics, fast-path
+counters, surface hash, and page errors.
+
+Reproduction identity:
+
+| Item | Value |
+| --- | --- |
+| java-tools base commit | `b70840200e76c9a135ac3df4b8c05c215b220266` |
+| Dekobloko JAR SHA-256 | `a22410ad930334f54672ce8acdf25d88c31e380550e8f88a5618bb730f3cf06e` |
+| Firefox | 146.0.1, Playwright Firefox build 1509 |
+| Node.js | 26.4.0 |
+| Viewport | 1000 × 800 |
+| Optimizer gates | renderer pipeline, scalar loops/bodies, fused regions, structured SSA |
+| Runtime mode | full mode, production bundle, real audio |
+| Tree state | dirty; only the files listed in this change belong to this experiment |
+
+Initial same-bundle A/B:
+
+| Configuration | Bundle SHA-256 | Presented | FPS | Raster runs | Fallbacks | Errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Disabled | `71ab8c2366663b05ca33f9356489e67b706e3fca18fbc90e4a1dd201e51436e7` | 185 | 12.32 | 0 | 0 | 0 |
+| Enabled | `71ab8c2366663b05ca33f9356489e67b706e3fca18fbc90e4a1dd201e51436e7` | 289 | 19.24 | 347,944 | 0 | 0 |
+
+This is a 56.1% increase in presented gameplay FPS. During the enabled
+15-second window, audio recorded one 37 ms underrun. The disabled control
+recorded one 70 ms underrun. Startup underruns are cumulative and are kept
+separate from the gameplay-window deltas.
+
+A later allocation-reduced bundle,
+`472477855b32e59e0148bd5dcf6d25eefd37a5c147e18349df051cb5cdf8df35`,
+keeps the same semantic proof and differential coverage. Its three clean
+enabled runs measured 18.51, 21.76, and 21.58 FPS: a **21.58 FPS median**.
+Every run had zero guarded fallbacks and zero page/runtime errors. Gameplay
+audio-gap deltas were 108, 75, and 38 ms (75 ms median). Run-to-run game timing
+varies, which is why the median is retained instead of a single displayed-FPS
+sample.
+
+The deployed follow-up bundle is
+`46ac49fb43d26a01a34e211beb3fd6867d3a4792114ab2d40fcea0b7248fb355`.
+Relative to the measured bundle, it only adds a pre-write integer-overflow
+proof and deduplicates cold dependency owners; the median above remains
+attributed to the exact measured `472477…` artifact.
+
+## Remaining bottleneck
+
+The optimization is worth retaining, but 18–19 FPS is not the 30 FPS target.
+It removes one large child body; the outer `qc`/UI scene family still owns the
+remaining frame time. The next profiling pass should run after this fast path
+is enabled, then target the new phase-local exclusive-time leader. Audio should
+continue to be judged by underrun duration during the same gameplay window:
+optimizing WebAudio conversion will not repair gaps caused by a long
+synchronous renderer interval.
+
+## Continuous WebAudio correction
+
+A later remote session confirmed the rendering result at 47–51 FPS but
+reported corrupted, rather than merely interrupted, audio. Telemetry separated
+the two cases: the audio queue remained near 0.79 seconds and underrun totals
+were often unchanged for tens of seconds.
+
+The browser bridge had represented every 256-frame 22.05 kHz
+`SourceDataLine.write` as a separate `AudioBufferSourceNode`. Firefox therefore
+had to restart its 22.05 kHz to device-rate conversion roughly 86 times per
+second for each active output. A Java `SourceDataLine` is one continuous PCM
+stream, so those artificial resampler boundaries were incorrect.
+
+The bridge now coalesces adjacent guest writes into capacity-aware continuous
+regions while counting staged PCM in `available()`:
+
+- the 65,536-byte stereo music line uses 2,048-frame regions;
+- the 8,192-byte effects line uses 512-frame regions;
+- an incomplete short effect is scheduled after at most 100 ms;
+- `flush`, `drain`, and `close` account for staged data explicitly; and
+- telemetry reports the negotiated format, guest writes, scheduled buffers,
+  removed boundaries, boundary jumps, saturation, and queued staged frames.
+
+The first real-mixer probe with fixed 2,048-frame regions verified 22,050 Hz,
+stereo, signed 16-bit little-endian PCM, reduced 8,998 guest writes to 1,111
+WebAudio buffers, recorded no saturated samples, and added zero underruns in
+the moving-gameplay window. The capacity-aware follow-up prevents the smaller
+effects line from retaining a partial sound indefinitely.

--- a/docs/dekobloko-firefox-performance.md
+++ b/docs/dekobloko-firefox-performance.md
@@ -5179,19 +5179,34 @@ animation timeline.
 The original guest lifecycle was subsequently audited end to end. It
 initializes the progress value to zero, increments it before drawing, renders
 1 through 250 at a 20 ms scheduler period, then takes its completion branch at
-251. The current diagnostic replays all 250 visible states, resets the captured
-initial raster only at the lifecycle boundary, and requires each complete loop
-to produce the same 307,200-pixel hash sequence. It deliberately excludes the
-raster array's extra sentinel element.
+251. The current diagnostic replays all 250 visible states and requires each
+complete loop to produce the same 307,200-pixel hash sequence. It deliberately
+excludes the raster array's extra sentinel element.
 
-Node 26.4 rendered two complete loops at 150.93 states/s with a 6.312 ms median
-guest state. Three clean headless Firefox 146.0.1 paced runs measured 34.06,
-35.63, and 33.63 states/s (34.06 median). Both runtimes produced loop hash
-`1069931322`, combined sequence hash `2650786977`, first hash `2929241493`,
-last hash `2521474463`, 175 unique surfaces, and 349/499 changed transitions.
-Firefox produced no page or JVM errors. The older 104 FPS Node and 42.61 FPS
-Firefox numbers are retained only as phase-jump throughput history and must not
-be cited as original-logo playback.
+The first full-timeline version still omitted the outer render path's
+per-frame framebuffer clear. Resetting only at a loop boundary left stale
+pixels and visible trails, so its hashes are invalid. The corrected harness
+finds the unique `()V` guest method that repeatedly reads the recovered raster
+field and stores zero without handlers, and executes that clear before every
+captured render. This is structural diagnostic selection, not an optimizer
+method-name rule.
+
+Node 26.4 rendered two corrected loops at 143.02 states/s with a 6.739 ms
+median guest state. Three clean headless Firefox 146.0.1 paced runs measured
+34.38, 31.45, and 34.56 states/s (34.38 median). Both runtimes produced loop
+hash `1711060353`, combined sequence hash `4093121037`, first hash
+`2929241493`, last hash `3053477317`, 225 unique surfaces, and 449/499 changed
+transitions. Firefox produced no page or JVM errors. Visual checkpoints at the
+reveal, highlight sweep, and completed logo no longer retain fragments from
+prior frames. The older 104 FPS Node and 42.61 FPS Firefox numbers are retained
+only as phase-jump throughput history and must not be cited as original-logo
+playback.
+
+One remote report measured 0.92 FPS, 1,079.9 ms median guest time, and
+7,923.696 scheduler slices per state. Its telemetry showed tier `generated`,
+mode `tight`, and zero structured/fused/scalar counters: it deliberately
+disabled the optimized path. The diagnostic now labels that choice “Slow
+control (optimizations off)” and warns prominently when selected.
 
 The measured browser bundle was
 `537299a0ff80342f0133e537bf4c082a8ea61b3e66074f066234a4eb892f7dee`;
@@ -5626,3 +5641,159 @@ locals and retains long cross-block local/join-slot copy chains. The next
 generic experiment should simplify SSA copies and phis, or split a verified
 region at safe boundaries; method-name-selected kernels are neither necessary
 nor justified by this profile.
+
+## 2026-07-29: archive, BZip2, kerning, and initialization-site audit
+
+This pass targeted bytecode and data-flow shapes only. No optimizer decision
+uses the guest names `eh`, `kh`, `ad`, `td`, or `mm`; those identities appear
+only in the diagnostic probe that reports which real game bodies exercised a
+generic rule.
+
+The three archive/reader bodies are not ordinary reducible scalar loops:
+
+- the 430-item reader/archive body has 15 retreating edges and an irreducible
+  CFG;
+- the 451-item cache reader has two retreating edges but fails structured
+  operand-stack verification;
+- the 758-item archive unpacker has 16 retreating edges and a verified
+  `dup_x2` form that the structured renderer cannot yet represent.
+
+All three also carry a boolean static across guest calls. Partial Wasm must
+continue rejecting that shape until every exit has a verifier-backed spill:
+losing the boolean local can change arbitrary control flow. A measured
+experiment that merely exposed the real backedges to the existing large
+switch-based JavaScript compiler increased Firefox first-paint time to
+35.477 seconds, so it was reverted. This is important negative evidence:
+making an existing tier accept more methods is not automatically an
+optimization.
+
+The retained generic changes are:
+
+- resolved instance fields in baseline generated bodies use their verified
+  owner-qualified object slot directly, with the generic resolver as fallback;
+- resolved static fields use direct map/object targets guarded by stable
+  class-initialization tokens;
+- interpreted `getstatic`, bytecode static calls, generated static calls, and
+  generated static fields reuse the same stable tokens instead of repeating a
+  `classInitializationState.get` at every hot site;
+- direct mutations and state restore refresh those tokens, preserving debugger
+  and snapshot semantics;
+- call-bearing structured SSA methods can cache non-volatile field reads, but
+  every guest call or field write invalidates the cache;
+- array-field values snapshot their raw storage companion, so invalidating or
+  rebinding a field cache cannot retarget an older live SSA array reference.
+
+The real BZip2 body compiles all 139/139 Wasm blocks and completed one measured
+run with zero exits. Its structured-JavaScript fallback now has 21 verified
+field caches and 37 direct sentinel-checked array loads. The real font-kerning
+body compiled 45/55 Wasm blocks, completed three measured runs with zero exits,
+and its structured fallback has two field caches. These are structural
+results, not guest-identity special cases.
+
+An opt-in dense-array policy was also added for experimentation. It requires a
+substantial method, at least 24 primitive-array operations, a real backedge,
+only statically linkable calls, and no dynamic calls. Enabling it by default
+moved Wasm compilation earlier but worsened the clean three-run Firefox
+first-paint median from 16.405 to 17.481 seconds. It remains disabled by
+default (`JVM_ENABLE_ARRAY_KERNEL_WASM_FIRST=1`) rather than shipping that
+regression.
+
+The final pre-load-spike interleaved control pair painted in 19.144 seconds for
+the old bundle and 18.563 seconds for the retained optimized build; the
+corresponding archive windows were 7.168 and 6.798 seconds. This is only a
+modest paired improvement and is not enough evidence for a broad speedup
+claim. Later three-run measurements became invalid for comparison because
+unrelated QEMU and Wine processes saturated the host: the optimized runs were
+20.247, 32.491, and 46.799 seconds, while a contemporaneous old-bundle control
+took 57.266 seconds. All recorded runs had zero page/runtime errors.
+
+The focused JIT suite passes 958/958 assertions. It checks structural
+dense-array selection and rejection, static-token invalidation, 100 warm
+interpreted static reads with one initial map lookup, 100 generated static
+reads with no repeated lookup, and array-field cache invalidation across guest
+effects. Scheduler/JIT edge tests pass 127/127, and the production build
+completes with only the existing four webpack size/dynamic-dependency warnings.
+
+Reproducibility:
+
+- java-tools commit before the dirty working changes:
+  `b70840200e76c9a135ac3df4b8c05c215b220266`;
+- final bundle SHA-256:
+  `8d1baab37604a7ea572e99cac1f0d387583366adfb453236cfb433b9bf821432`;
+- untouched `dekobloko.jar` SHA-256:
+  `a22410ad930334f54672ce8acdf25d88c31e380550e8f88a5618bb730f3cf06e`;
+- Node `v26.4.0`, npm `12.0.1`, Firefox Playwright build 1509;
+- browser query gate `schedulerRate=256`, default structured optimizer,
+  default Wasm JIT, dense-array Wasm-first disabled;
+- the java-tools tree was dirty with pre-existing audio, renderer, IDE, and
+  documentation work as well as this pass.
+
+## 2026-07-29: missing title instruments were a launcher override
+
+The title-screen music defect was not caused by WebAudio, stereo conversion,
+asset corruption, or the guest Vorbis implementation. The game launcher had
+registered an application-specific JRE override for the guest method with
+descriptor `(I)[F`; that override returned `null` for every packet. The normal
+guest caller treats `null` as “no overlap samples for this packet”, so it
+continued through the archive and constructed correctly sized, entirely
+zero-filled PCM buffers. This also explains why the isolated audio diagnostic,
+which did not install the launcher override, always sounded correct.
+
+The launcher override was removed. No guest class or method identity was added
+to the JIT, and a speculative structural JIT bailout was discarded after the
+override was found.
+
+The instrumented Firefox game then matched the standalone decoder exactly for
+the three title samples that had been silent:
+
+| decoded length | nonzero samples | FNV checksum |
+|---:|---:|---:|
+| 10,654 | 10,291 | 3,217,290,969 |
+| 13,203 | 12,098 | 2,371,258,599 |
+| 161,752 | 115,114 | 1,724,468,494 |
+
+The first large live decode likewise changed from 0 nonzero bytes to 302,827
+nonzero bytes out of 400,787. The title-mix report recorded no silent voices,
+and every observed voice backed by those samples changed its destination
+buffer.
+
+Validation used Firefox Playwright build 1509, production JVM bundle SHA-256
+`f32a24990fec7b742e3e9ed3dcda204efa361b4d485cec76a5676a3ea6379b82`,
+untouched game JAR SHA-256
+`a22410ad930334f54672ce8acdf25d88c31e380550e8f88a5618bb730f3cf06e`,
+and trace JAR SHA-256
+`67d907f87a071db647981a3cfe39c090ad334754394403c27bf1b759dcd3614f`.
+The focused JIT suite passed 963/963 assertions and the production bundle
+built successfully with the four existing size/dynamic-dependency warnings.
+
+## 2026-07-29: short sound effects and AudioWorklet startup buffering
+
+After restoring the music decoder, music was audible but the separate
+sound-effect output was not. Browser telemetry showed that this was downstream
+of the guest mixer: the 8 KiB `SourceDataLine` repeatedly supplied nonzero PCM
+with peaks up to roughly 0.5, while the 64 KiB music line played normally.
+
+The AudioWorklet used the same 80 ms startup cushion for both outputs. At
+22,050 Hz that is 1,764 frames, but the effect line naturally publishes
+512-frame regions and many observed short outputs contained only 1,024–1,536
+frames. Their PCM reached the worklet queue but could be replaced or closed
+before the processor ever started.
+
+Worklet startup now retains the 80 ms ceiling for continuous streams while
+limiting the threshold to the output's first natural coalesced region. The
+music line therefore remains at 1,764 frames and the effect line starts at 512
+frames. This is derived from negotiated format and buffer sizes; it contains
+no game, class, method, or track identity.
+
+The focused WebAudio test passes 34/34 assertions. Its fake worklet verifies
+that one 512-frame region both meets the effect-line threshold and is posted to
+the processor. A clean Firefox probe of the deployed game reported a running
+audio context and these live contracts:
+
+| line buffer | coalesced region | startup threshold |
+|---:|---:|---:|
+| 65,536 bytes | 2,048 frames | 1,764 frames |
+| 8,192 bytes | 512 frames | 512 frames |
+
+The deployed production bundle SHA-256 is
+`2fa7b65f454986bbdbd7849260b661817f67a35b30185bd0213c6493be1c8145`.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "generate": "node scripts/generateData.js",
     "build": "npm run generate && npm run build:bundle && node scripts/buildSite.js",
     "clean": "find sources -name '*.class' -delete && rm -rf dist",
-    "pretest": "node scripts/generate-jre-index.js &&npm run build:java",
+    "pretest": "node scripts/generate-jre-index.js && npm run build:java && npm run generate",
     "ci": "npm run build && npm test",
     "health-check": "node scripts/health-check.js",
     "lint:jasmin": "node scripts/jvm-cli.js lint",

--- a/src/core/jvm.js
+++ b/src/core/jvm.js
@@ -31,6 +31,34 @@ const JitCompiler = require("../jit/JitCompiler");
 const { encodeGraph, decodeGraph } = require("./stateCodec");
 const { createClock } = require('./fakeClock');
 
+class ClassInitializationStateMap extends Map {
+  constructor(jvm, entries = []) {
+    super();
+    this.jvm = jvm;
+    for (const [className, state] of entries) super.set(className, state);
+  }
+
+  set(className, state) {
+    super.set(className, state);
+    const token = this.jvm?.classInitializationTokens?.get(className);
+    if (token) {
+      token.state = state;
+      token.initialized = state === "INITIALIZED";
+    }
+    return this;
+  }
+
+  delete(className) {
+    const deleted = super.delete(className);
+    const token = this.jvm?.classInitializationTokens?.get(className);
+    if (token) {
+      token.state = undefined;
+      token.initialized = false;
+    }
+    return deleted;
+  }
+}
+
 let browserYieldChannel = null;
 const browserYieldQueue = [];
 
@@ -118,8 +146,14 @@ class JVM {
     // Bumped on every class registration; closed-world analyses (class
     // hierarchy, devirtualization facts) memoize against it.
     this.classEpoch = 0;
-    this.classInitializationState = new Map();
+    this.classInitializationState = new ClassInitializationStateMap(this);
     this.classInitializationOwners = new Map();
+    // Generated call/field sites retain these stable token objects. Java
+    // class initialization is monotonic during ordinary execution, so a hot
+    // site can read one boolean property instead of performing a Map lookup
+    // on every invocation. State restoration refreshes the existing tokens
+    // before generated code is discarded or resumed.
+    this.classInitializationTokens = new Map();
     // Separate from classEpoch because a loaded class can become initialized
     // without registering another class. Link-time JIT decisions that depend
     // on initialized statics memoize against both epochs.
@@ -1198,6 +1232,19 @@ class JVM {
 
     // console.error(`Tick. Current thread: ${this.currentThreadIndex}. Statuses: ${this.threads.map(t => `${t.id}:${t.status}`).join(', ')}`);
 
+    const audioPriority = this._audioPriority;
+    if (audioPriority && audioPriority.thread &&
+        audioPriority.thread.status === "runnable" &&
+        Date.now() <= audioPriority.until &&
+        audioPriority.output &&
+        typeof audioPriority.output.queuedSeconds === "function" &&
+        audioPriority.output.queuedSeconds() < 0.12) {
+      const priorityIndex = this.threads.indexOf(audioPriority.thread);
+      if (priorityIndex >= 0) this.currentThreadIndex = priorityIndex;
+    } else if (audioPriority) {
+      this._audioPriority = null;
+    }
+
     let thread = this.threads[this.currentThreadIndex];
 
     // Find the next runnable thread
@@ -1298,7 +1345,9 @@ class JVM {
       const popped = callStack.pop();
       this.completeClassInitialization(popped);
       
-      if (thread.isAwaitingReflectiveCall) {
+      if (thread.isAwaitingReflectiveCall &&
+          (!thread.reflectiveCallFrame ||
+            thread.reflectiveCallFrame === popped)) {
         let ret = null;
         if (!popped.stack.isEmpty()) {
           ret = popped.stack.pop();
@@ -1306,6 +1355,7 @@ class JVM {
         await thread.reflectiveCallResolver(ret);
         thread.isAwaitingReflectiveCall = false;
         thread.reflectiveCallResolver = null;
+        thread.reflectiveCallFrame = null;
       }
       return { completed: false };
     }
@@ -1822,7 +1872,7 @@ class JVM {
       console.log(`Initializing class: ${className}`);
     }
 
-    this.classInitializationState.set(className, "INITIALIZING");
+    this._setClassInitializationState(className, "INITIALIZING");
     this.classInitializationOwners.set(className, thread.id);
 
     // For JRE classes, we should already have them preloaded in this.classes
@@ -1855,6 +1905,11 @@ class JVM {
         );
         if (wasSuperPushed) {
           this.classInitializationState.delete(className);
+          const token = this.classInitializationTokens.get(className);
+          if (token) {
+            token.state = undefined;
+            token.initialized = false;
+          }
           this.classInitializationOwners.delete(className);
           return true;
         }
@@ -1978,7 +2033,7 @@ class JVM {
     if (this.classInitializationState.get(className) !== "INITIALIZED") {
       this.classInitializationEpoch += 1;
     }
-    this.classInitializationState.set(className, "INITIALIZED");
+    this._setClassInitializationState(className, "INITIALIZED");
     this.classInitializationOwners.delete(className);
     this._wakeClassInitializationWaiters(className);
   }
@@ -1994,9 +2049,36 @@ class JVM {
     const className = frame && frame.initializingClassName;
     if (!className) return;
     delete frame.initializingClassName;
-    this.classInitializationState.set(className, "ERRONEOUS");
+    this._setClassInitializationState(className, "ERRONEOUS");
     this.classInitializationOwners.delete(className);
     this._wakeClassInitializationWaiters(className);
+  }
+
+  getClassInitializationToken(className) {
+    let token = this.classInitializationTokens.get(className);
+    if (!token) {
+      const state = this.classInitializationState.get(className);
+      token = { state, initialized: state === "INITIALIZED" };
+      this.classInitializationTokens.set(className, token);
+    }
+    return token;
+  }
+
+  _setClassInitializationState(className, state) {
+    this.classInitializationState.set(className, state);
+    const token = this.classInitializationTokens.get(className);
+    if (token) {
+      token.state = state;
+      token.initialized = state === "INITIALIZED";
+    }
+  }
+
+  _refreshClassInitializationTokens() {
+    for (const [className, token] of this.classInitializationTokens) {
+      const state = this.classInitializationState.get(className);
+      token.state = state;
+      token.initialized = state === "INITIALIZED";
+    }
   }
 
   _wakeClassInitializationWaiters(className) {
@@ -2391,6 +2473,24 @@ class JVM {
   }
 
   handleException(exception, pc, thread) {
+    // Host exceptions retain their JavaScript stack, but normal JVM unwinding
+    // removes guest frames before BrowserJVMDebug can report them. Attach the
+    // deepest guest location once, on the exceptional path only, so failures
+    // such as an accidental BigInt/Number coercion identify the generated
+    // method and bytecode PC that caused them.
+    if (exception instanceof Error && !exception.jvmGuestLocation) {
+      const failingFrame = thread.callStack.isEmpty()
+        ? null : thread.callStack.peek();
+      if (failingFrame) {
+        const failingMethod = failingFrame.method || {};
+        exception.jvmGuestLocation = {
+          className: failingFrame.className || null,
+          methodName: failingMethod.name || null,
+          descriptor: failingMethod.descriptor || null,
+          pc: Number.isInteger(pc) && pc >= 0 ? pc : failingFrame.pc,
+        };
+      }
+    }
     if (this._envDebugThrow ||
         this._envDebugThrowType && exception &&
           exception.type === this._envDebugThrowType) {
@@ -2648,7 +2748,9 @@ class JVM {
     this._restoreSaveStateThreadRefs(decoded);
     this.currentThreadIndex = Math.min(state.currentThreadIndex || 0,
       Math.max(0, this.threads.length - 1));
-    this.classInitializationState = new Map(state.classInitializationState || []);
+    this.classInitializationState = new ClassInitializationStateMap(
+      this, state.classInitializationState || []);
+    this._refreshClassInitializationTokens();
     this.classInitializationOwners = new Map();
     for (const thread of this.threads) {
       for (const frame of thread.callStack.items) {
@@ -2789,7 +2891,9 @@ class JVM {
       }),
     );
     this.currentThreadIndex = state.currentThreadIndex;
-    this.classInitializationState = new Map(state.classInitializationState);
+    this.classInitializationState = new ClassInitializationStateMap(
+      this, state.classInitializationState);
+    this._refreshClassInitializationTokens();
     this.nextHashCode = state.nextHashCode;
     if (state.debugManager) {
       this.debugManager.deserialize(state.debugManager);

--- a/src/core/jvm.js
+++ b/src/core/jvm.js
@@ -19,6 +19,10 @@ const {
   syncFallback,
   syncInvokeFallback,
 } = dispatch;
+const {
+  isReflectiveTarget,
+  completeReflectiveCall,
+} = require("../instructions/control");
 const Frame = require("./frame");
 const DebugManager = require("../debug/DebugManager");
 const JNI = require("./jni");
@@ -1175,9 +1179,11 @@ class JVM {
 
   _prepareSchedulerTick() {
     // On each tick, check for threads that need to be woken up.
+    const audioPriority = this._audioPriority;
     const hasTimedThread = this.threads.some((t) =>
       (t.status === 'SLEEPING' && t.sleepUntil !== undefined) ||
-      (t.status === 'WAITING' && t.waitDeadline !== undefined));
+      (t.status === 'WAITING' && t.waitDeadline !== undefined)) ||
+      Boolean(audioPriority);
     const schedulerNow = hasTimedThread ? this.clock.millis() : 0;
     for (const t of this.threads) {
       if (t.status === "SLEEPING" && schedulerNow >= t.sleepUntil) {
@@ -1232,10 +1238,9 @@ class JVM {
 
     // console.error(`Tick. Current thread: ${this.currentThreadIndex}. Statuses: ${this.threads.map(t => `${t.id}:${t.status}`).join(', ')}`);
 
-    const audioPriority = this._audioPriority;
     if (audioPriority && audioPriority.thread &&
         audioPriority.thread.status === "runnable" &&
-        Date.now() <= audioPriority.until &&
+        schedulerNow <= audioPriority.until &&
         audioPriority.output &&
         typeof audioPriority.output.queuedSeconds === "function" &&
         audioPriority.output.queuedSeconds() < 0.12) {
@@ -1345,17 +1350,12 @@ class JVM {
       const popped = callStack.pop();
       this.completeClassInitialization(popped);
       
-      if (thread.isAwaitingReflectiveCall &&
-          (!thread.reflectiveCallFrame ||
-            thread.reflectiveCallFrame === popped)) {
+      if (isReflectiveTarget(thread, popped)) {
         let ret = null;
         if (!popped.stack.isEmpty()) {
           ret = popped.stack.pop();
         }
-        await thread.reflectiveCallResolver(ret);
-        thread.isAwaitingReflectiveCall = false;
-        thread.reflectiveCallResolver = null;
-        thread.reflectiveCallFrame = null;
+        await completeReflectiveCall(thread, ret);
       }
       return { completed: false };
     }

--- a/src/core/reflectionArguments.js
+++ b/src/core/reflectionArguments.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function unboxReflectiveArgument(parameterType, value) {
+  const boxedValue = value && typeof value === 'object' &&
+    Object.prototype.hasOwnProperty.call(value, 'value')
+    ? value.value : value;
+  switch (parameterType) {
+    case 'boolean': return boxedValue ? 1 : 0;
+    case 'byte':
+    case 'short':
+    case 'char':
+    case 'int':
+      return Number(boxedValue) | 0;
+    case 'long':
+      return typeof boxedValue === 'bigint'
+        ? boxedValue : BigInt(Math.trunc(Number(boxedValue)));
+    case 'float':
+    case 'double':
+      return Number(boxedValue);
+    default:
+      return value;
+  }
+}
+
+function assignReflectiveArguments(locals, args, params, startIndex) {
+  let localIndex = startIndex;
+  for (let index = 0; index < args.length; index += 1) {
+    locals[localIndex] = unboxReflectiveArgument(params[index], args[index]);
+    localIndex += params[index] === 'long' || params[index] === 'double'
+      ? 2 : 1;
+  }
+}
+
+module.exports = {
+  assignReflectiveArguments,
+  unboxReflectiveArgument,
+};

--- a/src/instructions/control.js
+++ b/src/instructions/control.js
@@ -28,7 +28,7 @@ function completeReflectiveCall(thread, value) {
   thread.isAwaitingReflectiveCall = false;
   thread.reflectiveCallResolver = null;
   thread.reflectiveCallFrame = null;
-  resolver(value);
+  return typeof resolver === 'function' ? resolver(value) : undefined;
 }
 
 module.exports = {
@@ -406,3 +406,9 @@ module.exports = {
       // No operation
     },
 };
+
+// Keep protocol helpers out of the opcode-handler spread in instructions/index.
+Object.defineProperties(module.exports, {
+  isReflectiveTarget: { value: isReflectiveTarget },
+  completeReflectiveCall: { value: completeReflectiveCall },
+});

--- a/src/instructions/control.js
+++ b/src/instructions/control.js
@@ -18,6 +18,19 @@ function targetPcFor(frame, label) {
   return target === undefined ? -1 : target;
 }
 
+function isReflectiveTarget(thread, frame) {
+  return thread.isAwaitingReflectiveCall &&
+    (!thread.reflectiveCallFrame || thread.reflectiveCallFrame === frame);
+}
+
+function completeReflectiveCall(thread, value) {
+  const resolver = thread.reflectiveCallResolver;
+  thread.isAwaitingReflectiveCall = false;
+  thread.reflectiveCallResolver = null;
+  thread.reflectiveCallFrame = null;
+  resolver(value);
+}
+
 module.exports = {
   return: (frame, instruction, jvm, thread) => {
     if (thread.pendingException) {
@@ -25,9 +38,8 @@ module.exports = {
     }
     thread.callStack.pop();
     jvm.completeClassInitialization(frame);
-    if (thread.isAwaitingReflectiveCall) {
-      thread.reflectiveCallResolver(null);
-      thread.isAwaitingReflectiveCall = false;
+    if (isReflectiveTarget(thread, frame)) {
+      completeReflectiveCall(thread, null);
     }
   },
   ireturn: (frame, instruction, jvm, thread) => {
@@ -36,9 +48,8 @@ module.exports = {
     }
     const returnValue = frame.stack.pop();
     thread.callStack.pop();
-    if (thread.isAwaitingReflectiveCall) {
-      thread.reflectiveCallResolver(returnValue);
-      thread.isAwaitingReflectiveCall = false;
+    if (isReflectiveTarget(thread, frame)) {
+      completeReflectiveCall(thread, returnValue);
     } else if (!thread.callStack.isEmpty()) {
       thread.callStack.peek().stack.push(returnValue);
     }
@@ -49,9 +60,8 @@ module.exports = {
     }
     const returnValue = frame.stack.pop();
     thread.callStack.pop();
-    if (thread.isAwaitingReflectiveCall) {
-      thread.reflectiveCallResolver(returnValue);
-      thread.isAwaitingReflectiveCall = false;
+    if (isReflectiveTarget(thread, frame)) {
+      completeReflectiveCall(thread, returnValue);
     } else if (!thread.callStack.isEmpty()) {
       thread.callStack.peek().stack.push(returnValue);
     }
@@ -353,9 +363,8 @@ module.exports = {
       }
       const returnValue = frame.stack.pop();
       thread.callStack.pop();
-      if (thread.isAwaitingReflectiveCall) {
-        thread.reflectiveCallResolver(returnValue);
-        thread.isAwaitingReflectiveCall = false;
+      if (isReflectiveTarget(thread, frame)) {
+        completeReflectiveCall(thread, returnValue);
       } else if (!thread.callStack.isEmpty()) {
         thread.callStack.peek().stack.push(returnValue);
       }
@@ -366,9 +375,8 @@ module.exports = {
       }
       const returnValue = frame.stack.pop();
       thread.callStack.pop();
-      if (thread.isAwaitingReflectiveCall) {
-        thread.reflectiveCallResolver(returnValue);
-        thread.isAwaitingReflectiveCall = false;
+      if (isReflectiveTarget(thread, frame)) {
+        completeReflectiveCall(thread, returnValue);
       } else if (!thread.callStack.isEmpty()) {
         thread.callStack.peek().stack.push(returnValue);
       }
@@ -379,9 +387,8 @@ module.exports = {
       }
       const returnValue = frame.stack.pop();
       thread.callStack.pop();
-      if (thread.isAwaitingReflectiveCall) {
-        thread.reflectiveCallResolver(returnValue);
-        thread.isAwaitingReflectiveCall = false;
+      if (isReflectiveTarget(thread, frame)) {
+        completeReflectiveCall(thread, returnValue);
       } else if (!thread.callStack.isEmpty()) {
         thread.callStack.peek().stack.push(returnValue);
       }

--- a/src/instructions/invoke.js
+++ b/src/instructions/invoke.js
@@ -38,6 +38,8 @@ function syncSiteState(instruction, descriptor) {
     target0: undefined,
     receiverClass1: null,
     target1: undefined,
+    initializationJvm: null,
+    initializationToken: null,
   };
   if (instruction && typeof instruction === 'object') {
     try {
@@ -136,7 +138,11 @@ function invokeBytecodeSync(frame, instruction, jvm, thread, kind) {
     state.target1 = undefined;
   }
   if (kind === 'static') {
-    const init = jvm.classInitializationState.get(className);
+    if (state.initializationJvm !== jvm) {
+      state.initializationJvm = jvm;
+      state.initializationToken = jvm.getClassInitializationToken(className);
+    }
+    const init = state.initializationToken.state;
     if (init !== 'INITIALIZED' &&
         !(init === 'INITIALIZING' &&
           jvm.classInitializationOwners.get(className) === thread.id)) {

--- a/src/instructions/invoke.js
+++ b/src/instructions/invoke.js
@@ -4,6 +4,9 @@ const Stack = require("../core/stack");
 const path = require("path");
 const { MethodHandle, MethodType, Lookup } = require("../jre/java/lang/invoke");
 const { ASYNC_METHOD_SENTINEL } = require("../core/constants");
+const {
+  classInitializationTokenFor,
+} = require('./utils');
 
 const resolvedSyncInvokeSite = Symbol('resolvedSyncInvokeSite');
 const SYNC_INVOKE_FALLBACK = Symbol('syncInvokeFallback');
@@ -38,8 +41,6 @@ function syncSiteState(instruction, descriptor) {
     target0: undefined,
     receiverClass1: null,
     target1: undefined,
-    initializationJvm: null,
-    initializationToken: null,
   };
   if (instruction && typeof instruction === 'object') {
     try {
@@ -138,11 +139,8 @@ function invokeBytecodeSync(frame, instruction, jvm, thread, kind) {
     state.target1 = undefined;
   }
   if (kind === 'static') {
-    if (state.initializationJvm !== jvm) {
-      state.initializationJvm = jvm;
-      state.initializationToken = jvm.getClassInitializationToken(className);
-    }
-    const init = state.initializationToken.state;
+    const init =
+      classInitializationTokenFor(jvm, instruction, className).state;
     if (init !== 'INITIALIZED' &&
         !(init === 'INITIALIZING' &&
           jvm.classInitializationOwners.get(className) === thread.id)) {

--- a/src/instructions/object.js
+++ b/src/instructions/object.js
@@ -1,3 +1,7 @@
+const {
+  classInitializationTokenFor,
+} = require('./utils');
+
 function runtimeClassName(objRef) {
   if (typeof objRef === 'string' || objRef instanceof String) {
     return 'java/lang/String';
@@ -30,7 +34,6 @@ function resolveInstanceFieldKey(jvm, objRef, className, fieldName) {
 // check keeps synthetic/JRE objects with unusual layouts on the full resolver.
 const resolvedInstanceFieldKey = Symbol('resolvedInstanceFieldKey');
 const resolvedStaticFieldSite = Symbol('resolvedStaticFieldSite');
-const resolvedStaticInitialization = Symbol('resolvedStaticInitialization');
 const SYNC_STATIC_FALLBACK = Symbol('syncStaticFallback');
 function resolveInstanceFieldKeyAtSite(jvm, objRef, instruction, className, fieldName) {
   if (instruction && typeof instruction === 'object') {
@@ -117,23 +120,8 @@ function readStaticFieldSite(jvm, site) {
 
 function getstaticSync(frame, instruction, jvm, thread) {
   const [_, className, [fieldName, descriptor]] = instruction.arg;
-  let initialization = instruction && instruction[resolvedStaticInitialization];
-  if (!initialization || initialization.jvm !== jvm) {
-    initialization = {
-      jvm,
-      token: jvm.getClassInitializationToken(className),
-    };
-    if (instruction && typeof instruction === 'object') {
-      try {
-        Object.defineProperty(instruction, resolvedStaticInitialization, {
-          configurable: true, writable: true, value: initialization,
-        });
-      } catch (_) {
-        // Frozen diagnostic fixtures retain the uncached token lookup.
-      }
-    }
-  }
-  const state = initialization.token.state;
+  const state =
+    classInitializationTokenFor(jvm, instruction, className).state;
   if (state !== 'INITIALIZED' &&
       !(state === 'INITIALIZING' &&
         jvm.classInitializationOwners.get(className) === thread.id)) {

--- a/src/instructions/object.js
+++ b/src/instructions/object.js
@@ -30,6 +30,7 @@ function resolveInstanceFieldKey(jvm, objRef, className, fieldName) {
 // check keeps synthetic/JRE objects with unusual layouts on the full resolver.
 const resolvedInstanceFieldKey = Symbol('resolvedInstanceFieldKey');
 const resolvedStaticFieldSite = Symbol('resolvedStaticFieldSite');
+const resolvedStaticInitialization = Symbol('resolvedStaticInitialization');
 const SYNC_STATIC_FALLBACK = Symbol('syncStaticFallback');
 function resolveInstanceFieldKeyAtSite(jvm, objRef, instruction, className, fieldName) {
   if (instruction && typeof instruction === 'object') {
@@ -116,7 +117,23 @@ function readStaticFieldSite(jvm, site) {
 
 function getstaticSync(frame, instruction, jvm, thread) {
   const [_, className, [fieldName, descriptor]] = instruction.arg;
-  const state = jvm.classInitializationState.get(className);
+  let initialization = instruction && instruction[resolvedStaticInitialization];
+  if (!initialization || initialization.jvm !== jvm) {
+    initialization = {
+      jvm,
+      token: jvm.getClassInitializationToken(className),
+    };
+    if (instruction && typeof instruction === 'object') {
+      try {
+        Object.defineProperty(instruction, resolvedStaticInitialization, {
+          configurable: true, writable: true, value: initialization,
+        });
+      } catch (_) {
+        // Frozen diagnostic fixtures retain the uncached token lookup.
+      }
+    }
+  }
+  const state = initialization.token.state;
   if (state !== 'INITIALIZED' &&
       !(state === 'INITIALIZING' &&
         jvm.classInitializationOwners.get(className) === thread.id)) {

--- a/src/instructions/utils.js
+++ b/src/instructions/utils.js
@@ -1,3 +1,28 @@
+const resolvedClassInitializationToken = Symbol('resolvedClassInitializationToken');
+
+function classInitializationTokenFor(jvm, instruction, className) {
+  let initialization =
+    instruction && instruction[resolvedClassInitializationToken];
+  if (!initialization || initialization.jvm !== jvm) {
+    initialization = {
+      jvm,
+      token: jvm.getClassInitializationToken(className),
+    };
+    if (instruction && typeof instruction === 'object') {
+      try {
+        Object.defineProperty(instruction, resolvedClassInitializationToken, {
+          configurable: true,
+          writable: true,
+          value: initialization,
+        });
+      } catch (_) {
+        // Frozen diagnostic fixtures retain the uncached token lookup.
+      }
+    }
+  }
+  return initialization.token;
+}
+
 function normalizeArrayLoad(value, kind, arrayRef) {
   if (!kind) {
     kind = arrayRef.type === "[B" || arrayRef.type === "[Z" ? "baload"
@@ -167,6 +192,7 @@ function _astore(frame, kind) {
 }
 
 module.exports = {
+  classInitializationTokenFor,
   _aload,
   _astore,
   normalizeArrayLoad,

--- a/src/instructions/utils.js
+++ b/src/instructions/utils.js
@@ -49,6 +49,25 @@ function _aload(frame, kind) {
   const arrayRef = frame.stack.pop();
 
   if (arrayRef === null || arrayRef === undefined) {
+    if (typeof process !== "undefined" && process.env &&
+        process.env.JVM_DEBUG_NULL_ARRAY === "1") {
+      const receiver = frame.locals && frame.locals[0];
+      const fields = receiver && receiver.fields
+        ? Object.fromEntries(Object.entries(receiver.fields).map(([key, fieldValue]) => [
+          key,
+          diagnosticScalar(fieldValue),
+        ]))
+        : null;
+      console.error("[null-array-load]", JSON.stringify({
+        owner: diagnosticScalar(frame.className),
+        method: `${frame.method && frame.method.name}${frame.method && frame.method.descriptor || ""}`,
+        pc: frame.pc - 1,
+        index: diagnosticScalar(index),
+        receiverType: diagnosticScalar(receiver && receiver.type),
+        fields,
+        locals: (frame.locals || []).map(diagnosticScalar),
+      }));
+    }
     throw {
       type: "java/lang/NullPointerException",
       message: `Attempted to load from null array in ${frame.method.name}`,

--- a/src/jit/HandwrittenAffineSpriteRaster.js
+++ b/src/jit/HandwrittenAffineSpriteRaster.js
@@ -1,0 +1,441 @@
+"use strict";
+
+// Semantic replacement for a column-oriented affine sprite/mask rasterizer.
+// Recognition is independent of guest class, method, and field names:
+//
+// - the complete descriptor and verified CFG/stack shape must match;
+// - the method must call the same verified (III)I helper exactly twice;
+// - repeated instance/static field relationships must match; and
+// - identity-canonicalized bytecode fingerprints must identify an audited
+//   compiler layout of the same algorithm.
+//
+// Entry validates all array/layout assumptions before the first pixel write.
+// A rejected entry therefore delegates to the canonical implementation with
+// no fused side effect and retains its normal Java exception semantics.
+
+const FusedRegionCompiler = require("./FusedRegionCompiler");
+const { fingerprintMethods } = require("./HandwrittenFusedGradient");
+
+const DESCRIPTOR = /^\(L[^;]+;L[^;]+;IIIIIIZZII\)V$/;
+const KNOWN_CALLER_FINGERPRINTS = new Set([
+  1773827786, // original classfile
+  1163529563, // decompile + javac
+]);
+const KNOWN_HELPER_FINGERPRINTS = new Set([
+  1778623157,
+  182681963,
+]);
+const KNOWN_SUITE_FINGERPRINTS = new Set([
+  2237033000,
+  1400128061,
+]);
+
+function getOp(instruction) {
+  return typeof instruction === "string" ? instruction : instruction && instruction.op;
+}
+
+function refKey(ref) {
+  return JSON.stringify(ref);
+}
+
+function uniqueRefs(refs) {
+  const result = [];
+  const seen = new Set();
+  for (const ref of refs) {
+    const key = refKey(ref);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(ref);
+  }
+  return result;
+}
+
+function descriptorOf(ref) {
+  return Array.isArray(ref) && Array.isArray(ref[2]) ? ref[2][1] : null;
+}
+
+function ownerOf(ref) {
+  return Array.isArray(ref) ? ref[1] : null;
+}
+
+function instructions(jit, method) {
+  return jit.getCodeItems(method)
+    .map((item) => item && item.instruction)
+    .filter((instruction) => getOp(instruction));
+}
+
+function resolveMethod(jit, instruction) {
+  const ref = instruction?.arg;
+  if (!Array.isArray(ref) || !Array.isArray(ref[2])) return null;
+  const classData = jit.jvm.classes[ref[1]];
+  return classData
+    ? jit.jvm.findMethod(classData, ref[2][0], ref[2][1]) || null
+    : null;
+}
+
+function codeIsVerified(jit, method) {
+  const codeItems = jit.getCodeItems(method);
+  if (!codeItems.length) return false;
+  const code = method.attributes?.find((attribute) => attribute.type === "code");
+  const handlers = code?.code?.exceptionTable || [];
+  if (handlers.length && !jit.hasOnlyNoOpExceptionHandlers(method, codeItems)) {
+    return false;
+  }
+  const labels = FusedRegionCompiler._test.buildLabelMap(codeItems);
+  return Boolean(jit.computeStackDepths(codeItems, labels));
+}
+
+function matchingCalls(jit, method) {
+  return instructions(jit, method).filter((instruction) =>
+    getOp(instruction) === "invokestatic" &&
+    Array.isArray(instruction.arg) &&
+    Array.isArray(instruction.arg[2]) &&
+    instruction.arg[2][1] === "(III)I");
+}
+
+// This cheap probe exists only so a caller can be reconsidered after its
+// structurally referenced helper owner loads. Full installation still requires
+// the complete suite proof in analyze().
+function candidateDependencies(jit, method, descriptor) {
+  if (!DESCRIPTOR.test(descriptor) ||
+      !KNOWN_CALLER_FINGERPRINTS.has(fingerprintMethods(jit, [method]))) {
+    return null;
+  }
+  const calls = matchingCalls(jit, method);
+  if (calls.length !== 2 || refKey(calls[0].arg) !== refKey(calls[1].arg)) {
+    return null;
+  }
+  return [calls[0].arg[1]];
+}
+
+function analyze(jit, method, descriptor) {
+  if (!DESCRIPTOR.test(descriptor) ||
+      !(method.flags || []).includes("static") ||
+      !codeIsVerified(jit, method)) return null;
+  const callerFingerprint = fingerprintMethods(jit, [method]);
+  if (!KNOWN_CALLER_FINGERPRINTS.has(callerFingerprint)) return null;
+
+  const calls = matchingCalls(jit, method);
+  if (calls.length !== 2 || refKey(calls[0].arg) !== refKey(calls[1].arg)) {
+    return null;
+  }
+  const helperMethod = resolveMethod(jit, calls[0]);
+  if (!helperMethod || !(helperMethod.flags || []).includes("static") ||
+      !codeIsVerified(jit, helperMethod)) return null;
+  const helperFingerprint = fingerprintMethods(jit, [helperMethod]);
+  const suiteFingerprint = fingerprintMethods(jit, [method, helperMethod]);
+  if (!KNOWN_HELPER_FINGERPRINTS.has(helperFingerprint) ||
+      !KNOWN_SUITE_FINGERPRINTS.has(suiteFingerprint)) return null;
+
+  const code = instructions(jit, method);
+  const instanceRefs = code
+    .filter((instruction) => getOp(instruction) === "getfield")
+    .map((instruction) => instruction.arg);
+  const staticRefs = code
+    .filter((instruction) => getOp(instruction) === "getstatic")
+    .map((instruction) => instruction.arg);
+  const instanceInts = uniqueRefs(instanceRefs.filter((ref) => descriptorOf(ref) === "I"));
+  const instancePixels = uniqueRefs(instanceRefs.filter((ref) => descriptorOf(ref) === "[I"));
+  const instanceMasks = uniqueRefs(instanceRefs.filter((ref) => descriptorOf(ref) === "[B"));
+  const staticInts = uniqueRefs(staticRefs.filter((ref) => descriptorOf(ref) === "I"));
+  const staticPixels = uniqueRefs(staticRefs.filter((ref) => descriptorOf(ref) === "[I"));
+
+  if (instanceInts.length !== 2 || instancePixels.length !== 1 ||
+      instanceMasks.length !== 1 || staticInts.length !== 5 ||
+      staticPixels.length !== 1) return null;
+  const exactlyTwice = (ref) =>
+    staticRefs.filter((candidate) => refKey(candidate) === refKey(ref)).length === 2;
+  if (![...staticInts, ...staticPixels].every(exactlyTwice)) return null;
+
+  // Fingerprinting proves the instruction order. First-use order now gives
+  // semantic roles without consulting any owner/member spelling.
+  return {
+    callerFingerprint,
+    helperFingerprint,
+    suiteFingerprint,
+    helperMethod,
+    classOwners: uniqueRefs([
+      method.className || jit.jvm.findClassNameForMethod?.(method) || null,
+      calls[0].arg[1],
+      ...instanceRefs.map(ownerOf),
+      ...staticRefs.map(ownerOf),
+    ].filter(Boolean)),
+    fields: {
+      spriteWidth: instanceInts[0],
+      spriteHeight: instanceInts[1],
+      spritePixels: instancePixels[0],
+      maskPixels: instanceMasks[0],
+      clipOuterStart: staticInts[0],
+      clipOuterEnd: staticInts[1],
+      clipInnerStart: staticInts[2],
+      clipInnerEnd: staticInts[3],
+      surfaceStride: staticInts[4],
+      destination: staticPixels[0],
+    },
+  };
+}
+
+function readLocation(location) {
+  return location.kind === "map"
+    ? location.fields.get(location.key)
+    : location.fields[location.key];
+}
+
+function bindStaticLocation(jit, ref) {
+  const site = jit.registerFieldSite(ref);
+  const direct = jit.registerDirectStaticTarget(site) ||
+    jit.registerDirectStaticTarget(site, true);
+  return direct ? jit.directStaticTargets[direct.targetId] || null : null;
+}
+
+function javaDivide(numerator, denominator) {
+  return (numerator / denominator) | 0;
+}
+
+// The verified helper computes floor division for a positive denominator.
+// Its unused first parameter is intentionally absent from this scalar form.
+function roundedFloorDivide(denominator, numerator) {
+  const sign = numerator >>> 31;
+  return (javaDivide((numerator + sign) | 0, denominator) - sign) | 0;
+}
+
+function runRaster(data, args) {
+  const {
+    width, height, source, mask, destination,
+    clipOuterStart, clipOuterEnd, clipInnerStart, clipInnerEnd, surfaceStride,
+  } = data;
+  let [
+    outerStart, outerEnd, leftStart, leftEnd, rightStart, rightEnd,
+    dim, blend, sourceOffset, maskOverride,
+  ] = args.map((value) => value | 0);
+  const outerSpan = (outerEnd - outerStart) | 0;
+  let firstOuter = outerStart;
+  if (firstOuter < clipOuterStart) firstOuter = clipOuterStart;
+  let lastOuter = outerEnd;
+  if (lastOuter > clipOuterEnd) lastOuter = clipOuterEnd;
+  if (firstOuter >= lastOuter) return true;
+
+  const sourceLength = width * height;
+  if (outerSpan <= 0 || width <= 0 || height <= 0 ||
+      !Number.isSafeInteger(sourceLength) || sourceLength > 0x7fffffff ||
+      source.length < sourceLength ||
+      (mask && mask.length < sourceLength) ||
+      surfaceStride <= 0 || clipOuterStart < 0 || clipOuterEnd < clipOuterStart ||
+      clipInnerStart < 0 || clipInnerEnd < clipInnerStart ||
+      clipOuterEnd > surfaceStride ||
+      sourceOffset < 0 || sourceOffset > (0x7fffffff - width) ||
+      (maskOverride >= 0 && maskOverride >= width)) return false;
+
+  const lastDestination =
+    (clipInnerEnd - 1) * surfaceStride + (clipOuterEnd - 1);
+  if (clipInnerEnd > clipInnerStart &&
+      (!Number.isSafeInteger(lastDestination) ||
+       lastDestination < 0 || lastDestination >= destination.length)) return false;
+
+  const leftDelta = (leftEnd - leftStart) | 0;
+  const rightDelta = (rightEnd - rightStart) | 0;
+  // Validate every row's division denominator before the first write. Source
+  // coordinates need no row pass: with positive span/width and non-negative
+  // offset, the verified clamp and remainder always produce [0, width).
+  for (let outer = firstOuter; outer < lastOuter; outer += 1) {
+    const offset = (outer - outerStart) | 0;
+    const left = (
+      Math.imul(leftStart, outerSpan) +
+      Math.imul(leftDelta, offset) +
+      (leftDelta >> 1)
+    ) | 0;
+    const right = (
+      Math.imul(rightStart, outerSpan) +
+      Math.imul(rightDelta, offset) +
+      (rightDelta >> 1)
+    ) | 0;
+    const innerSpan = (right - left) | 0;
+    const sourceLimit = height * innerSpan;
+    if (innerSpan <= 0 || !Number.isSafeInteger(sourceLimit) ||
+        sourceLimit > 0x7fffffff) return false;
+  }
+
+  for (let outer = firstOuter; outer < lastOuter; outer += 1) {
+    const offset = (outer - outerStart) | 0;
+    let maskX = javaDivide(
+      (Math.imul(width, offset) + (outerSpan >> 1)) | 0, outerSpan);
+    if (maskX >= width) maskX = (width - 1) | 0;
+    const sourceX = ((maskX + sourceOffset) | 0) % width;
+    if (maskOverride >= 0) maskX = maskOverride;
+    const left = (
+      Math.imul(leftStart, outerSpan) +
+      Math.imul(leftDelta, offset) +
+      (leftDelta >> 1)
+    ) | 0;
+    const right = (
+      Math.imul(rightStart, outerSpan) +
+      Math.imul(rightDelta, offset) +
+      (rightDelta >> 1)
+    ) | 0;
+    const innerSpan = (right - left) | 0;
+    let firstInner = roundedFloorDivide(
+      outerSpan, (left + (outerSpan >> 1)) | 0);
+    if (firstInner < clipInnerStart) firstInner = clipInnerStart;
+    let lastInner = roundedFloorDivide(
+      outerSpan, (right + (outerSpan >> 1)) | 0);
+    if (lastInner > clipInnerEnd) lastInner = clipInnerEnd;
+    if (lastInner <= firstInner) continue;
+
+    let sourceFixed = (
+      Math.imul(height, (Math.imul(firstInner, outerSpan) - left) | 0) +
+      (innerSpan >> 1)
+    ) | 0;
+    let sourceFixedLast = (
+      Math.imul(height,
+        (Math.imul((lastInner - 1) | 0, outerSpan) - left) | 0) +
+      (innerSpan >> 1)
+    ) | 0;
+    if (sourceFixed <= -innerSpan) sourceFixed = (-innerSpan + 1) | 0;
+    const sourceLimit = Math.imul(height, innerSpan);
+    if (sourceFixed >= sourceLimit) sourceFixed = (sourceLimit - 1) | 0;
+    if (sourceFixedLast >= sourceLimit) sourceFixedLast = (sourceLimit - 1) | 0;
+    let sourceStep = 0;
+    if (sourceFixedLast > sourceFixed) {
+      const innerDenominator = (lastInner - firstInner - 1) | 0;
+      sourceStep = javaDivide(
+        (sourceFixedLast - sourceFixed) | 0, innerDenominator);
+    }
+
+    let destinationIndex =
+      (Math.imul(firstInner, surfaceStride) + outer) | 0;
+    for (let inner = firstInner; inner < lastInner; inner += 1) {
+      const sourceY = javaDivide(sourceFixed, innerSpan);
+      const sourceRow = Math.imul(sourceY, width);
+      let color = source[(sourceRow + sourceX) | 0] | 0;
+      if (color !== 0 &&
+          (!mask || (mask[(sourceRow + maskX) | 0] | 0) !== 0)) {
+        if (dim) color = (color >> 1) & 8355711;
+        if (blend) {
+          color = (
+            color + ((destination[destinationIndex] >> 1) & 8355711)
+          ) | 0;
+        }
+        destination[destinationIndex] = color;
+      }
+      destinationIndex = (destinationIndex + surfaceStride) | 0;
+      sourceFixed = (sourceFixed + sourceStep) | 0;
+    }
+  }
+  return true;
+}
+
+function createIntrinsic(jit, method, descriptor, sentinels) {
+  if (!jit.affineSpriteRasterEnabled) return null;
+  const plan = analyze(jit, method, descriptor);
+  if (!plan) return null;
+  const { ASYNC_INVOKE, RETURN_VOID } = sentinels;
+  const fieldSites = {
+    spriteWidth: jit.registerFieldSite(plan.fields.spriteWidth),
+    spriteHeight: jit.registerFieldSite(plan.fields.spriteHeight),
+    spritePixels: jit.registerFieldSite(plan.fields.spritePixels),
+    maskPixels: jit.registerFieldSite(plan.fields.maskPixels),
+  };
+  const fieldKeys = Object.fromEntries(Object.entries(fieldSites).map(
+    ([name, site]) => [name, jit.fieldSites[site]?.directInstanceKey || null]));
+  const locations = {
+    clipOuterStart: bindStaticLocation(jit, plan.fields.clipOuterStart),
+    clipOuterEnd: bindStaticLocation(jit, plan.fields.clipOuterEnd),
+    clipInnerStart: bindStaticLocation(jit, plan.fields.clipInnerStart),
+    clipInnerEnd: bindStaticLocation(jit, plan.fields.clipInnerEnd),
+    surfaceStride: bindStaticLocation(jit, plan.fields.surfaceStride),
+    destination: bindStaticLocation(jit, plan.fields.destination),
+  };
+  if (Object.values(fieldKeys).some((key) => !key) ||
+      Object.values(locations).some((location) => !location)) return null;
+
+  function fallback() {
+    jit.affineSpriteRasterGuardedFallbackCount =
+      (jit.affineSpriteRasterGuardedFallbackCount | 0) + 1;
+    return ASYNC_INVOKE;
+  }
+
+  function ready() {
+    if (jit._envInstrumented || jit.needsBytecodeChecks()) return false;
+    for (const owner of plan.classOwners) {
+      if (jit.jvm.classInitializationState.get(owner) !== "INITIALIZED" ||
+          jit.jvm.debugManager.isClassJitDeopted(owner)) return false;
+    }
+    return true;
+  }
+
+  function run(sprite, maskObject,
+    outerStart, outerEnd, leftStart, leftEnd, rightStart, rightEnd,
+    dim, blend, sourceOffset, maskOverride) {
+    if (!ready() || sprite === null || sprite === undefined) return fallback();
+    let widthValue;
+    let heightValue;
+    let sourceRef;
+    let maskRef = null;
+    const spriteFields = sprite.fields;
+    const maskFields = maskObject?.fields;
+    if (!spriteFields ||
+        (maskObject !== null && maskObject !== undefined && !maskFields)) {
+      return fallback();
+    }
+    widthValue = spriteFields[fieldKeys.spriteWidth];
+    heightValue = spriteFields[fieldKeys.spriteHeight];
+    sourceRef = spriteFields[fieldKeys.spritePixels];
+    if (maskObject !== null && maskObject !== undefined) {
+      maskRef = maskFields[fieldKeys.maskPixels];
+    }
+    if (!Number.isInteger(widthValue) || !Number.isInteger(heightValue)) {
+      return fallback();
+    }
+    const source = jit.arrayData(sourceRef);
+    const mask = maskObject === null || maskObject === undefined
+      ? null : jit.arrayData(maskRef);
+    const destinationRef = readLocation(locations.destination);
+    const destination = jit.arrayData(destinationRef);
+    if (!source || !destination ||
+        (maskObject !== null && maskObject !== undefined && !mask)) {
+      return fallback();
+    }
+    const accepted = runRaster({
+      width: widthValue | 0,
+      height: heightValue | 0,
+      source,
+      mask,
+      destination,
+      clipOuterStart: readLocation(locations.clipOuterStart) | 0,
+      clipOuterEnd: readLocation(locations.clipOuterEnd) | 0,
+      clipInnerStart: readLocation(locations.clipInnerStart) | 0,
+      clipInnerEnd: readLocation(locations.clipInnerEnd) | 0,
+      surfaceStride: readLocation(locations.surfaceStride) | 0,
+    }, [
+      outerStart, outerEnd, leftStart, leftEnd, rightStart, rightEnd,
+      dim, blend, sourceOffset, maskOverride,
+    ]);
+    if (!accepted) return fallback();
+    jit.affineSpriteRasterRunCount = (jit.affineSpriteRasterRunCount | 0) + 1;
+    return RETURN_VOID;
+  }
+
+  const intrinsic = (stack, base) => run(
+    stack[base], stack[base + 1], stack[base + 2], stack[base + 3],
+    stack[base + 4], stack[base + 5], stack[base + 6], stack[base + 7],
+    stack[base + 8], stack[base + 9], stack[base + 10], stack[base + 11],
+  );
+  intrinsic.jvmDirectKind = "affineSpriteRaster";
+  intrinsic.jvmDirectData = { plan, run };
+  intrinsic.jvmPositional = run;
+  return intrinsic;
+}
+
+module.exports = {
+  analyze,
+  candidateDependencies,
+  createIntrinsic,
+  DESCRIPTOR,
+  _test: {
+    KNOWN_CALLER_FINGERPRINTS,
+    KNOWN_HELPER_FINGERPRINTS,
+    KNOWN_SUITE_FINGERPRINTS,
+    roundedFloorDivide,
+    runRaster,
+  },
+};

--- a/src/jit/JitCompiler.js
+++ b/src/jit/JitCompiler.js
@@ -16,6 +16,10 @@ const {
   normalizeArrayLoad,
   normalizeArrayStore,
 } = require("../instructions/utils");
+const {
+  isReflectiveTarget,
+  completeReflectiveCall,
+} = require("../instructions/control");
 const { buildSsa } = require("../analysis/opgraph/ssa");
 const { kindWidth } = require("../analysis/opgraph/ssaTypes");
 const { capturesBooleanStatic, isNoOpExceptionHandler } = WasmJit._test;
@@ -556,7 +560,7 @@ class JitCompiler {
       const op = getOp(item && item.instruction);
       if (!op) continue;
       instructionCount += 1;
-      if (/^(?:[abcdfils]aload|[abcdfils]astore|arraylength)$/.test(op)) {
+      if (/^(?:[bcdfils]aload|[bcdfils]astore|arraylength)$/.test(op)) {
         primitiveArrayAccessCount += 1;
       }
       if (op === "invokestatic") staticCallCount += 1;
@@ -655,14 +659,11 @@ class JitCompiler {
       return HANDLED_RESULT;
     }
     if (result && result.returned) {
-      const reflectiveReturn = thread.isAwaitingReflectiveCall &&
-        (!thread.reflectiveCallFrame || thread.reflectiveCallFrame === frame);
-      if (reflectiveReturn) {
-        const resolver = thread.reflectiveCallResolver;
-        thread.isAwaitingReflectiveCall = false;
-        thread.reflectiveCallResolver = null;
-        thread.reflectiveCallFrame = null;
-        resolver(result.value === RETURN_VOID ? null : result.value);
+      if (isReflectiveTarget(thread, frame)) {
+        completeReflectiveCall(
+          thread,
+          result.value === RETURN_VOID ? null : result.value,
+        );
       } else if (result.value !== RETURN_VOID && !thread.callStack.isEmpty()) {
         thread.callStack.peek().stack.push(result.value);
       }
@@ -3136,7 +3137,8 @@ class JitCompiler {
           const key = JSON.stringify(site.directInstanceKey);
           const fieldName = JSON.stringify(site.fieldName);
           return `{ const value = stack[--sp]; const object = stack[--sp]; ` +
-            `if (object !== null && object !== undefined && object.fields) { ` +
+            `if (object !== null && object !== undefined && object.fields && ` +
+            `Object.prototype.hasOwnProperty.call(object.fields, ${key})) { ` +
             `object.fields[${key}] = value; object[${fieldName}] = value; ` +
             `} else { helpers.putFieldAt(${fieldSiteId}, object, value); } } ${goNext}`;
         }
@@ -4326,6 +4328,9 @@ class JitCompiler {
 
   tryInvokeSync(op, frame, instruction, thread) {
     const [, declaredClassName, [methodName, descriptor]] = instruction.arg;
+    const initializationToken = op === "invokestatic"
+      ? this.jvm.getClassInitializationToken(declaredClassName)
+      : null;
     return this.tryInvokeSyncSite({
       op,
       declaredClassName,
@@ -4333,6 +4338,7 @@ class JitCompiler {
       descriptor,
       ...parseDescriptor(descriptor),
       targets: new Map(),
+      initializationToken,
     }, frame, thread);
   }
 

--- a/src/jit/JitCompiler.js
+++ b/src/jit/JitCompiler.js
@@ -4281,6 +4281,11 @@ class JitCompiler {
       target.positionalInvoker =
         generated.jvmRestoringDirectPositionalBody.bind(null, this, plan);
       target.positionalInvoker.jvmDebugGuarded = true;
+      // The restoring scalar ABI reconstructs an omitted child Frame at the
+      // precise throwing operation. Its caller must therefore retain the
+      // invoke pc and operands until the ordinary exception dispatcher has
+      // processed that reconstructed frame.
+      target.positionalInvoker.jvmRestoresExceptionFrames = true;
       return target.positionalInvoker;
     }
     const argumentsList = Array.from(

--- a/src/jit/JitCompiler.js
+++ b/src/jit/JitCompiler.js
@@ -10,6 +10,7 @@ const JvmSsaBlockRenderer = require("./JvmSsaBlockRenderer");
 const HandwrittenPolygonRaster = require("./HandwrittenPolygonRaster");
 const HandwrittenTiledBlit = require("./HandwrittenTiledBlit");
 const HandwrittenPerspectiveSpan = require("./HandwrittenPerspectiveSpan");
+const HandwrittenAffineSpriteRaster = require("./HandwrittenAffineSpriteRaster");
 const monoArray = require("./monoArray");
 const {
   normalizeArrayLoad,
@@ -118,6 +119,13 @@ class JitCompiler {
     this.perspectiveSpanIntrinsicCache = new WeakMap();
     this.perspectiveSpanRunCount = 0;
     this.perspectiveSpanGuardedFallbackCount = 0;
+    this.affineSpriteRasterEnabled =
+      options.affineSpriteRaster !== false &&
+      !(typeof process !== "undefined" && process.env &&
+        process.env.JVM_DISABLE_AFFINE_SPRITE_RASTER === "1");
+    this.affineSpriteRasterIntrinsicCache = new WeakMap();
+    this.affineSpriteRasterRunCount = 0;
+    this.affineSpriteRasterGuardedFallbackCount = 0;
     this.semanticBilinearSamplerRunCount = 0;
     this.semanticBilinearSamplerFallbackCount = 0;
     this.transparentIntBlitRunCount = 0;
@@ -256,6 +264,12 @@ class JitCompiler {
       options.longArithmeticWasmFirst !== false &&
       !(typeof process !== "undefined" && process.env &&
         process.env.JVM_DISABLE_LONG_ARITHMETIC_WASM_FIRST === "1");
+    this.arrayKernelWasmFirstMethods = new WeakMap();
+    this.arrayKernelWasmFirstMethodCount = 0;
+    this.arrayKernelWasmFirstEnabled =
+      options.arrayKernelWasmFirst === true ||
+      Boolean(typeof process !== "undefined" && process.env &&
+        process.env.JVM_ENABLE_ARRAY_KERNEL_WASM_FIRST === "1");
     this.rendererPipelineEnabled = options.rendererPipeline === true ||
       Boolean(typeof process !== "undefined" && process.env &&
         process.env.JVM_ENABLE_RENDERER_PIPELINE === "1");
@@ -396,7 +410,8 @@ class JitCompiler {
     }
     const wasmPriorityLoop = this.wasmJit.enabled &&
       (this.isOversizedLoopMethod(frame.method) ||
-        this.isLongArithmeticLoopMethod(frame.method));
+        this.isLongArithmeticLoopMethod(frame.method) ||
+        this.isArrayKernelWasmFirstMethod(frame.method));
     const wholeMethodPreferred =
       this.prefersWholeMethodJs(frame.method) && !wasmPriorityLoop;
     if (wholeMethodPreferred && canProbeGenerated) {
@@ -524,6 +539,45 @@ class JitCompiler {
     return selected;
   }
 
+  isArrayKernelWasmFirstMethod(method) {
+    if (!this.arrayKernelWasmFirstEnabled ||
+        !method || method.name === "<init>" || method.name === "<clinit>") {
+      return false;
+    }
+    if (this.arrayKernelWasmFirstMethods.has(method)) {
+      return this.arrayKernelWasmFirstMethods.get(method);
+    }
+    const codeItems = this.getCodeItems(method);
+    let instructionCount = 0;
+    let primitiveArrayAccessCount = 0;
+    let staticCallCount = 0;
+    let nonStaticCallCount = 0;
+    for (const item of codeItems) {
+      const op = getOp(item && item.instruction);
+      if (!op) continue;
+      instructionCount += 1;
+      if (/^(?:[abcdfils]aload|[abcdfils]astore|arraylength)$/.test(op)) {
+        primitiveArrayAccessCount += 1;
+      }
+      if (op === "invokestatic") staticCallCount += 1;
+      else if (op === "invokevirtual" || op === "invokeinterface" ||
+          op === "invokespecial") nonStaticCallCount += 1;
+    }
+    // Dense primitive-array kernels with only statically linkable helpers are
+    // a better fit for Wasm than a JavaScript generator: the loops keep
+    // unboxed indices/values and linked helper calls stay in one module.
+    // Require substantial bytecode and array density so ordinary archive/UI
+    // methods do not pay module compilation or Wasm/JS transition costs.
+    const selected = instructionCount >= 192 &&
+      primitiveArrayAccessCount >= 24 &&
+      staticCallCount <= 32 &&
+      nonStaticCallCount === 0 &&
+      this.hasBackwardBranch(method);
+    this.arrayKernelWasmFirstMethods.set(method, selected);
+    if (selected) this.arrayKernelWasmFirstMethodCount += 1;
+    return selected;
+  }
+
   prefersWholeMethodJs(method) {
     return this.preferWholeMethodJs ||
       this.adaptiveCodegenMethods.has(method);
@@ -600,8 +654,18 @@ class JitCompiler {
       }
       return HANDLED_RESULT;
     }
-    if (result && result.returned && result.value !== RETURN_VOID && !thread.callStack.isEmpty()) {
-      thread.callStack.peek().stack.push(result.value);
+    if (result && result.returned) {
+      const reflectiveReturn = thread.isAwaitingReflectiveCall &&
+        (!thread.reflectiveCallFrame || thread.reflectiveCallFrame === frame);
+      if (reflectiveReturn) {
+        const resolver = thread.reflectiveCallResolver;
+        thread.isAwaitingReflectiveCall = false;
+        thread.reflectiveCallResolver = null;
+        thread.reflectiveCallFrame = null;
+        resolver(result.value === RETURN_VOID ? null : result.value);
+      } else if (result.value !== RETURN_VOID && !thread.callStack.isEmpty()) {
+        thread.callStack.peek().stack.push(result.value);
+      }
     }
     return HANDLED_RESULT;
   }
@@ -3055,21 +3119,59 @@ class JitCompiler {
       }
       case "getfield": {
         const fieldSiteId = this.registerFieldSite(instruction.arg);
+        const site = this.fieldSites[fieldSiteId];
+        if (site.directInstanceKey) {
+          const key = JSON.stringify(site.directInstanceKey);
+          return `{ const object = stack[sp - 1]; stack[sp - 1] = ` +
+            `(object !== null && object !== undefined && object.fields && ` +
+            `object.fields[${key}] !== undefined) ? object.fields[${key}] : ` +
+            `helpers.getFieldAt(${fieldSiteId}, object); } ${goNext}`;
+        }
         return `stack[sp - 1] = helpers.getFieldAt(${fieldSiteId}, stack[sp - 1]); ${goNext}`;
       }
       case "putfield": {
         const fieldSiteId = this.registerFieldSite(instruction.arg);
+        const site = this.fieldSites[fieldSiteId];
+        if (site.directInstanceKey) {
+          const key = JSON.stringify(site.directInstanceKey);
+          const fieldName = JSON.stringify(site.fieldName);
+          return `{ const value = stack[--sp]; const object = stack[--sp]; ` +
+            `if (object !== null && object !== undefined && object.fields) { ` +
+            `object.fields[${key}] = value; object[${fieldName}] = value; ` +
+            `} else { helpers.putFieldAt(${fieldSiteId}, object, value); } } ${goNext}`;
+        }
         return `{ const value = stack[--sp]; helpers.putFieldAt(${fieldSiteId}, stack[--sp], value); } ${goNext}`;
       }
       case "getstatic":
         if (this.compileSynchronous) {
           const fieldSiteId = this.registerFieldSite(instruction.arg);
+          const direct = this.registerDirectStaticTarget(fieldSiteId);
+          if (direct) {
+            const target = `helpers.directStaticTargets[${direct.targetId}]`;
+            const read = direct.kind === "map"
+              ? `${target}.fields.get(${JSON.stringify(direct.key)})`
+              : `${target}.fields[${JSON.stringify(direct.key)}]`;
+            return `{ const target = ${target}; if (!target.initializationToken.initialized) { ` +
+              `helpers.materializeCached(frame, locals, stack, sp, ${index}); ` +
+              `helpers.skipJitOnce(frame); return { deopt: true, transient: true, ` +
+              `reason: "class initialization at direct synchronous getstatic" }; } ` +
+              `stack[sp++] = ${read}; } ${goNext}`;
+          }
           return `{ const value = helpers.getStaticSyncAt(${fieldSiteId}); if (value === helpers.staticDeopt()) { helpers.materializeCached(frame, locals, stack, sp, ${index}); helpers.skipJitOnce(frame); return { deopt: true, transient: true, reason: "class initialization at synchronous getstatic" }; } stack[sp++] = value; } ${goNext}`;
         }
         return `{ let value = helpers.getStatic(${JSON.stringify(instruction.arg)}, thread); if (value && typeof value.then === "function") value = await value; if (value === helpers.staticDeopt()) { helpers.materializeCached(frame, locals, stack, sp, ${index}); return { deopt: true, transient: true, reason: "class initialization at generated getstatic" }; } stack[sp++] = value; } ${goNext}`;
       case "putstatic":
         if (this.compileSynchronous) {
           const fieldSiteId = this.registerFieldSite(instruction.arg);
+          const direct = this.registerDirectStaticTarget(fieldSiteId, true);
+          if (direct?.kind === "map") {
+            const target = `helpers.directStaticTargets[${direct.targetId}]`;
+            return `{ const target = ${target}; if (!target.initializationToken.initialized) { ` +
+              `helpers.materializeCached(frame, locals, stack, sp, ${index}); ` +
+              `helpers.skipJitOnce(frame); return { deopt: true, transient: true, ` +
+              `reason: "class initialization at direct synchronous putstatic" }; } ` +
+              `target.fields.set(${JSON.stringify(direct.key)}, stack[--sp]); } ${goNext}`;
+          }
           return `{ const changed = helpers.putStaticSyncAt(${fieldSiteId}, stack[sp - 1]); if (changed === helpers.staticDeopt()) { helpers.materializeCached(frame, locals, stack, sp, ${index}); helpers.skipJitOnce(frame); return { deopt: true, transient: true, reason: "class initialization at synchronous putstatic" }; } sp -= 1; } ${goNext}`;
         }
         return `{ let changed = helpers.putStatic(${JSON.stringify(instruction.arg)}, stack[sp - 1], thread); if (changed && typeof changed.then === "function") changed = await changed; if (changed === helpers.staticDeopt()) { helpers.materializeCached(frame, locals, stack, sp, ${index}); return { deopt: true, transient: true, reason: "class initialization at generated putstatic" }; } sp -= 1; } ${goNext}`;
@@ -3757,6 +3859,7 @@ class JitCompiler {
       className,
       fieldName,
       descriptor,
+      initializationToken: this.jvm.getClassInitializationToken(className),
       directKey: `${className}.${fieldName}`,
       directInstanceKey,
       instanceKeys: new Map(),
@@ -3888,6 +3991,7 @@ class JitCompiler {
     }
     if (!target || (forWrite && target.kind !== "map")) return null;
     site.staticTarget = target;
+    target.initializationToken = site.initializationToken;
     const targetId = this.directStaticTargets.length;
     this.directStaticTargets.push(target);
     return { targetId, kind: target.kind, key: target.key, className: site.className };
@@ -3896,7 +4000,7 @@ class JitCompiler {
   getStaticSyncAt(id) {
     const site = this.fieldSites[id];
     if (!site) throw new Error(`Unknown generated static field site ${id}`);
-    if (this.jvm.classInitializationState.get(site.className) !== "INITIALIZED") {
+    if (!site.initializationToken.initialized) {
       return STATIC_DEOPT;
     }
     let target = site.staticTarget;
@@ -3915,7 +4019,7 @@ class JitCompiler {
   putStaticSyncAt(id, value) {
     const site = this.fieldSites[id];
     if (!site) throw new Error(`Unknown generated static field site ${id}`);
-    if (this.jvm.classInitializationState.get(site.className) !== "INITIALIZED") {
+    if (!site.initializationToken.initialized) {
       return STATIC_DEOPT;
     }
     let target = site.staticTarget;
@@ -4106,6 +4210,8 @@ class JitCompiler {
       declaredClassName,
       methodName,
       descriptor,
+      initializationToken:
+        this.jvm.getClassInitializationToken(declaredClassName),
       ...parseDescriptor(descriptor),
       targets: new Map(),
     };
@@ -4147,7 +4253,7 @@ class JitCompiler {
     }
     const fast = site.fastIntrinsic;
     if (fast) {
-      if (this.jvm.classInitializationState.get(site.declaredClassName) !== "INITIALIZED" ||
+      if (!site.initializationToken.initialized ||
           this.jvm.debugManager.isClassJitDeopted(fast.lookupClass)) {
         return ASYNC_INVOKE;
       }
@@ -4166,7 +4272,7 @@ class JitCompiler {
     }
     const target = site.fastStaticTarget;
     if (target) {
-      if (this.jvm.classInitializationState.get(site.declaredClassName) !== "INITIALIZED") {
+      if (!site.initializationToken.initialized) {
         return ASYNC_INVOKE;
       }
       return this.tryInvokeResolvedTarget(site, target, frame, thread);
@@ -4302,7 +4408,7 @@ class JitCompiler {
       local += site.params[index] === "long" || site.params[index] === "double" ? 2 : 1;
     }
     const staticGuard = site.op === "invokestatic"
-      ? `if (jit.jvm.classInitializationState.get(plan.staticOwner) !== "INITIALIZED") return plan.asyncInvoke;`
+      ? `if (!plan.staticInitialization.initialized) return plan.asyncInvoke;`
       : "";
     const tracePattern = typeof process !== "undefined" && process.env
       ? process.env.JVM_TRACE_POSITIONAL_GENERATED || "" : "";
@@ -4429,6 +4535,7 @@ class JitCompiler {
         jit: this,
         target,
         Frame,
+        staticInitialization: site.initializationToken,
         method,
         methodKey,
         generated,
@@ -4482,7 +4589,7 @@ class JitCompiler {
       : `plan.method(plan.jvm, ${receiver}, [${
         callArguments.join(", ")}], thread)`;
     const staticGuard = site.op === "invokestatic"
-      ? `if (plan.jvm.classInitializationState.get(plan.staticOwner) !== "INITIALIZED") return plan.asyncInvoke;`
+      ? `if (!plan.staticInitialization.initialized) return plan.asyncInvoke;`
       : "";
     const source = [
       "'use strict';",
@@ -4507,6 +4614,7 @@ class JitCompiler {
         method: target.method,
         direct,
         staticOwner: site.declaredClassName,
+        staticInitialization: site.initializationToken,
         asyncMethod: ASYNC_METHOD_SENTINEL,
         asyncInvoke: ASYNC_INVOKE,
         returnVoid: RETURN_VOID,
@@ -4522,7 +4630,7 @@ class JitCompiler {
   tryInvokeSyncSite(site, frame, thread) {
     const { op, declaredClassName, methodName, descriptor, params, returnType } = site;
     if (op === "invokestatic" &&
-        this.jvm.classInitializationState.get(declaredClassName) !== "INITIALIZED") {
+        !site.initializationToken.initialized) {
       return ASYNC_INVOKE;
     }
 
@@ -4595,11 +4703,21 @@ class JitCompiler {
       const structuralIntrinsic = op === "invokestatic"
         ? this.getSynchronousIntrinsic(method, descriptor)
         : null;
-      const pendingIntrinsicOwners = op === "invokestatic" && !structuralIntrinsic
-        ? HandwrittenPolygonRaster.candidateDependencies(this, method, descriptor)
+      const pendingIntrinsicCandidates =
+        op === "invokestatic" && !structuralIntrinsic ? [
+          ...(HandwrittenPolygonRaster.candidateDependencies(
+            this, method, descriptor) || []),
+          ...(HandwrittenAffineSpriteRaster.candidateDependencies(
+            this, method, descriptor) || []),
+        ] : null;
+      const pendingIntrinsicOwners = pendingIntrinsicCandidates?.length
+        ? [...new Set(pendingIntrinsicCandidates)]
         : null;
       if (!normallySupported && !fusedCandidate &&
-          !structuralIntrinsic && !pendingIntrinsicOwners) return ASYNC_INVOKE;
+          !structuralIntrinsic &&
+          (!pendingIntrinsicOwners || pendingIntrinsicOwners.length === 0)) {
+        return ASYNC_INVOKE;
+      }
       target = {
         method,
         lookupClass,
@@ -4950,6 +5068,17 @@ class JitCompiler {
   }
 
   getSynchronousIntrinsic(method, descriptor) {
+    if (HandwrittenAffineSpriteRaster.DESCRIPTOR.test(descriptor)) {
+      if (this.affineSpriteRasterIntrinsicCache.has(method)) {
+        return this.affineSpriteRasterIntrinsicCache.get(method);
+      }
+      const affineSpriteRaster = HandwrittenAffineSpriteRaster.createIntrinsic(
+        this, method, descriptor, { ASYNC_INVOKE, RETURN_VOID, STATIC_DEOPT });
+      if (affineSpriteRaster) {
+        this.affineSpriteRasterIntrinsicCache.set(method, affineSpriteRaster);
+        return affineSpriteRaster;
+      }
+    }
     if (descriptor === HandwrittenPerspectiveSpan.DESCRIPTOR) {
       if (this.perspectiveSpanIntrinsicCache.has(method)) {
         return this.perspectiveSpanIntrinsicCache.get(method);
@@ -6591,7 +6720,8 @@ class JitCompiler {
     } else if (intrinsic.jvmDirectKind === "polygonFlatRaster" ||
         intrinsic.jvmDirectKind === "polygonAlphaRaster" ||
         intrinsic.jvmDirectKind === "tiledIntArrayBlit" ||
-        intrinsic.jvmDirectKind === "perspectiveTexturedSpan") {
+        intrinsic.jvmDirectKind === "perspectiveTexturedSpan" ||
+        intrinsic.jvmDirectKind === "affineSpriteRaster") {
       if (typeof intrinsic.jvmPositional !== "function") return null;
       direct.positionalId = this.directSynchronousIntrinsics.length;
       this.directSynchronousIntrinsics.push(intrinsic.jvmPositional);

--- a/src/jit/JvmSsaBlockRenderer.js
+++ b/src/jit/JvmSsaBlockRenderer.js
@@ -453,31 +453,29 @@ class JvmSsaBlockRenderer {
     });
     const fieldReadCaches = new Map();
     const fieldReadCacheSites = new Map();
-    if (!hasUnknownFieldEffect) {
-      for (let index = 0; index < items.length; index += 1) {
-        const instruction = items[index]?.instruction;
-        if (opOf(instruction) !== "getfield" ||
-            !this.jit.canEliminateFieldRead(instruction.arg)) continue;
-        const key = JSON.stringify(instruction.arg);
-        let cache = fieldReadCaches.get(key);
-        if (!cache) {
-          const number = fieldReadCaches.size;
-          const site = fieldSites.get(index);
-          cache = {
-            object: `ssaFieldCache${number}Object`,
-            value: `ssaFieldCache${number}Value`,
-            valid: `ssaFieldCache${number}Valid`,
-            data: `ssaFieldCache${number}ArrayData`,
-            site,
-            indexes: [],
-            isArray: this.jit.fieldSites[site]?.descriptor?.startsWith("[") === true,
-            directKey: this.jit.fieldSites[site]?.directInstanceKey || null,
-          };
-          fieldReadCaches.set(key, cache);
-        }
-        cache.indexes.push(index);
-        fieldReadCacheSites.set(index, cache);
+    for (let index = 0; index < items.length; index += 1) {
+      const instruction = items[index]?.instruction;
+      if (opOf(instruction) !== "getfield" ||
+          !this.jit.canEliminateFieldRead(instruction.arg)) continue;
+      const key = JSON.stringify(instruction.arg);
+      let cache = fieldReadCaches.get(key);
+      if (!cache) {
+        const number = fieldReadCaches.size;
+        const site = fieldSites.get(index);
+        cache = {
+          object: `ssaFieldCache${number}Object`,
+          value: `ssaFieldCache${number}Value`,
+          valid: `ssaFieldCache${number}Valid`,
+          data: `ssaFieldCache${number}ArrayData`,
+          site,
+          indexes: [],
+          isArray: this.jit.fieldSites[site]?.descriptor?.startsWith("[") === true,
+          directKey: this.jit.fieldSites[site]?.directInstanceKey || null,
+        };
+        fieldReadCaches.set(key, cache);
       }
+      cache.indexes.push(index);
+      fieldReadCacheSites.set(index, cache);
     }
     const methodIsStatic = (method.flags || []).includes("static") ||
       (Number(method.accessFlags) & 0x0008) !== 0;
@@ -496,9 +494,15 @@ class JvmSsaBlockRenderer {
         op === "aload" && Number(instruction?.arg) === 0;
     };
     for (const cache of fieldReadCaches.values()) {
-      cache.eagerThis = !methodIsStatic && !localZeroAssigned &&
+      cache.eagerThis = !hasUnknownFieldEffect &&
+        !methodIsStatic && !localZeroAssigned &&
         cache.indexes.every(directlyLoadsThis);
     }
+    const invalidateFieldReadCaches = () =>
+      [...fieldReadCaches.values()].flatMap((cache) => [
+        `${cache.valid} = false;`,
+        ...(cache.isArray ? [`${cache.data} = null;`] : []),
+      ]);
     // javac has to give source-level temporaries a value before the first
     // structured try/loop join.  Decompiled methods can consequently start
     // with dozens of `iconst_0; istore` / `aconst_null; astore` pairs.  The
@@ -779,6 +783,7 @@ class JvmSsaBlockRenderer {
       // value only within the block and only until a call/static write, so a
       // scheduler safe point or arbitrary guest effect can never stale it.
       const directStaticBlockValues = new Map();
+      const fieldArraySnapshots = new Map();
       // A successful primitive load proves that the same array/index pair is
       // non-null and in bounds for the remainder of this straight-line basic
       // block. Java primitive arrays never contain `undefined`, so a raw
@@ -1134,7 +1139,6 @@ class JvmSsaBlockRenderer {
             lines.push(`const ${object} = ${objectInput};`);
             if (cache?.eagerThis) {
               lines.push(`const ${out} = ${cache.value};`);
-              if (cache.isArray) arrayViews.set(out, cache.data);
             } else {
               lines.push(`if (${object} === null || ${object} === undefined) {`,
                 ...materializeLines([...stack, object], index).map((line) => `  ${line}`),
@@ -1149,20 +1153,34 @@ class JvmSsaBlockRenderer {
                 `  ${cache.value} = ${out};`,
                 ...(cache.isArray ? [`  ${cache.data} = helpers.arrayData(${out});`] : []),
                 `  ${cache.valid} = true;`, "}");
-              if (cache.isArray) arrayViews.set(out, cache.data);
             } else if (!cache) {
               lines.push(`const ${out} = ${directRead};`);
+            }
+            if (cache?.isArray) {
+              // The field cache may be invalidated or rebound by a later
+              // guest call/write while this earlier array reference remains
+              // live on the SSA operand stack. Snapshot its storage companion
+              // so future cache maintenance cannot retarget this value.
+              let dataSnapshot = fieldArraySnapshots.get(cache);
+              if (!dataSnapshot) {
+                dataSnapshot = value();
+                lines.push(`const ${dataSnapshot} = ${cache.data};`);
+                fieldArraySnapshots.set(cache, dataSnapshot);
+              }
+              arrayViews.set(out, dataSnapshot);
             }
             stack.push(out);
           }
         } else if (op === "putfield") {
+          fieldArraySnapshots.clear();
           const storedInput = pop(), objectInput = pop(), site = fieldSites.get(index);
           if (storedInput === null || objectInput === null || site === undefined) valid = false;
           else {
             const object = value(), stored = value();
             const fieldPlan = this.jit.fieldSites[site];
             const directKey = fieldPlan?.directInstanceKey || null;
-            lines.push(`const ${object} = ${objectInput};`, `const ${stored} = ${storedInput};`,
+            lines.push(...invalidateFieldReadCaches(),
+              `const ${object} = ${objectInput};`, `const ${stored} = ${storedInput};`,
               `if (${object} === null || ${object} === undefined) {`,
               ...materializeLines([...stack, object, stored], index).map((line) => `  ${line}`),
               `  helpers.putFieldAt(${site}, ${object}, ${stored});`, "}",
@@ -1231,6 +1249,8 @@ class JvmSsaBlockRenderer {
         } else if (op === "invokestatic" || op === "invokevirtual" ||
             op === "invokespecial" || op === "invokeinterface") {
           directStaticBlockValues.clear();
+          fieldArraySnapshots.clear();
+          lines.push(...invalidateFieldReadCaches());
           const site = callSites.get(index);
           if (!site || stack.length < site.argumentCount) valid = false;
           else if (site.directJre) {
@@ -1344,7 +1364,8 @@ class JvmSsaBlockRenderer {
           } else if ((site.directIntrinsic?.kind === "polygonFlatRaster" ||
               site.directIntrinsic?.kind === "polygonAlphaRaster" ||
               site.directIntrinsic?.kind === "tiledIntArrayBlit" ||
-              site.directIntrinsic?.kind === "perspectiveTexturedSpan") &&
+              site.directIntrinsic?.kind === "perspectiveTexturedSpan" ||
+              site.directIntrinsic?.kind === "affineSpriteRaster") &&
               Number.isInteger(site.directIntrinsic.positionalId) &&
               site.directIntrinsic.returnsVoid) {
             const callStack = [...stack];
@@ -1362,7 +1383,7 @@ class JvmSsaBlockRenderer {
                 `if (${result} === helpers.asyncInvokeSentinel()) {`,
                 ...materializeLines(callStack, index).map((line) => `  ${line}`),
                 "  helpers.skipJitOnce(frame);",
-                "  return { deopt: true, transient: true, reason: 'guarded polygon raster fallback' };", "}");
+                "  return { deopt: true, transient: true, reason: 'guarded direct raster fallback' };", "}");
             }
           } else if (site.directIntrinsic?.kind === "maskedColorBlit" &&
               site.directIntrinsic.paramCount === 9 && site.directIntrinsic.returnsVoid) {

--- a/src/jit/JvmSsaBlockRenderer.js
+++ b/src/jit/JvmSsaBlockRenderer.js
@@ -581,6 +581,22 @@ class JvmSsaBlockRenderer {
       `stack.length = ${operandValues.length};`,
       `helpers.materialize(frame, locals, stack, ${pc});`,
     ];
+    // A synchronous guest call can throw after installing its child Frame.
+    // If that child catches the exception, its eventual return must resume
+    // this frame after the invoke with only the operands below the arguments.
+    // If no child was installed (for example, a direct JRE intrinsic threw),
+    // the exception belongs to this frame and must retain the invoke pc and
+    // complete pre-call stack for normal handler dispatch.
+    const materializeCallExceptionLines = (
+      preCallValues, postCallValues, pc, childCanResume = "true",
+    ) => [
+      `if (${childCanResume} && thread.callStack.items.length && ` +
+        "thread.callStack.peek() !== frame) {",
+      ...materializeLines(postCallValues, pc + 1).map((line) => `  ${line}`),
+      "} else {",
+      ...materializeLines(preCallValues, pc).map((line) => `  ${line}`),
+      "}",
+    ];
     const stageOperandLines = (operandValues) => [
       ...operandValues.map((expression, i) => `stack[${i}] = ${expression};`),
       `stack.length = ${operandValues.length};`,
@@ -1473,7 +1489,8 @@ class JvmSsaBlockRenderer {
                   ? stageOperandLines(callStack) : materializeLines(callStack, index + 1)),
                 `let ${out};`,
                 `try { ${out} = helpers.tryInvokeSyncAt(${site.id}, frame, thread); } catch (${caught}) {`,
-                ...materializeLines(callStack, index).map((line) => `  ${line}`),
+                ...materializeCallExceptionLines(callStack, stack, index)
+                  .map((line) => `  ${line}`),
                 `  throw ${caught};`, "}",
                 `if (${out} === helpers.asyncInvokeSentinel()) {`,
                 asynchronousFallbackMarker, "}",
@@ -1524,7 +1541,9 @@ class JvmSsaBlockRenderer {
               ...(deferMaterialization
                 ? stageOperandLines(callStack) : materializeLines(callStack, index + 1)),
               `try { ${out} = helpers.tryInvokeSyncAt(${site.id}, frame, thread); } catch (${caught}) {`,
-              ...materializeLines(callStack, index).map((line) => `  ${line}`), `  throw ${caught};`, "}",
+              ...materializeCallExceptionLines(callStack, stack, index)
+                .map((line) => `  ${line}`),
+              `  throw ${caught};`, "}",
               `if (${out} === helpers.asyncInvokeSentinel()) {`,
               ...(resumableVoidCall ? [asynchronousCallMarker] : [
                 ...materializeLines(callStack, index).map((line) => `  ${line}`),
@@ -1551,7 +1570,11 @@ class JvmSsaBlockRenderer {
                 `      !helpers.jvm.debugManager.isClassJitDeopted(${positionalTarget}.lookupClass))) {`,
                 `  try { ${out} = ${positionalTarget}.invoke(${args.join(", ")}${
                   args.length ? ", " : ""}thread); } catch (${caught}) {`,
-                ...materializeLines(callStack, index).map((line) => `    ${line}`),
+                ...materializeCallExceptionLines(
+                  callStack, stack, index,
+                  `!${positionalTarget}.invoke.jvmRestoresExceptionFrames`,
+                )
+                  .map((line) => `    ${line}`),
                 `    throw ${caught};`, "  }",
                 `  if (${out} === helpers.asyncInvokeSentinel()) {`,
                 ...fallbackLines.map((line) => `    ${line}`),

--- a/src/jit/WasmJit.js
+++ b/src/jit/WasmJit.js
@@ -77,6 +77,7 @@ const {
   NPE, AIOOBE,
   BRANCH_COND, BRANCH_ZERO, ICONST, BIN_OPS, ARRAY_LOAD, ARRAY_STORE,
   MATH_INTRINSICS,
+  mathIntrinsicFunction,
   Unsupported,
   NestedDeopt,
   isGuestThrow,
@@ -504,10 +505,8 @@ class MethodTranslator {
     }
     const wParams = params.map(descToWasm);
     const wRet = descToWasm(ret);
-    const jsFn = Math[name];
-    const fn = ret === 'F'
-      ? (...args) => Math.fround(jsFn(...args))
-      : (...args) => jsFn(...args);
+    const fn = mathIntrinsicFunction(name, descriptor);
+    if (!fn) throw new Unsupported(`Math.${name}${descriptor} unsupported`);
     return {
       params: wParams,
       ret: wRet,

--- a/src/jit/WasmJit.js
+++ b/src/jit/WasmJit.js
@@ -64,7 +64,8 @@
 
 const { resolveInstanceFieldKey, runtimeClassName } = require('../instructions/object');
 const {
-  addTimeImport, addNewArrayImport, addANewArrayImport, addNewImport,
+  addMathImport, addTimeImport, addNewArrayImport, addANewArrayImport,
+  addNewImport,
 } = require('./wasmRuntimeImports');
 const { ClassHierarchy } = require('../analysis/closedWorld/classHierarchy');
 const { revalidateSpeculations } = require('./wasmInline');
@@ -76,8 +77,6 @@ const {
   getOp, descToWasm, toWasmValue, parseMethodDescriptor, sig,
   NPE, AIOOBE,
   BRANCH_COND, BRANCH_ZERO, ICONST, BIN_OPS, ARRAY_LOAD, ARRAY_STORE,
-  MATH_INTRINSICS,
-  mathIntrinsicFunction,
   Unsupported,
   NestedDeopt,
   isGuestThrow,
@@ -495,23 +494,7 @@ class MethodTranslator {
   }
 
   mathIntrinsic(ins) {
-    const [, className, [name, descriptor]] = ins.arg;
-    if (className !== 'java/lang/Math' || !MATH_INTRINSICS.has(name)) {
-      throw new Unsupported(`invoke ${className}.${name}`);
-    }
-    const { params, ret } = parseMethodDescriptor(descriptor);
-    if (![...params, ret].every((c) => 'IJFD'.includes(c))) {
-      throw new Unsupported(`Math.${name}${descriptor} non-numeric`);
-    }
-    const wParams = params.map(descToWasm);
-    const wRet = descToWasm(ret);
-    const fn = mathIntrinsicFunction(name, descriptor);
-    if (!fn) throw new Unsupported(`Math.${name}${descriptor} unsupported`);
-    return {
-      params: wParams,
-      ret: wRet,
-      idx: this.addImport(`math_${name}_${descriptor}`.replace(/[^\w]/g, '_'), wParams, [wRet], fn),
-    };
+    return addMathImport(this, ins);
   }
 
   // invokestatic bound directly to another compiled wasm method. A callee

--- a/src/jit/wasmRuntimeImports.js
+++ b/src/jit/wasmRuntimeImports.js
@@ -15,6 +15,7 @@ const {
 } = require('../instructions/object');
 const {
   T, NPE, AIOOBE, MATH_INTRINSICS, Unsupported,
+  mathIntrinsicFunction,
   descToWasm, toWasmValue, parseMethodDescriptor,
 } = require('./wasmShared');
 const monoArray = require('./monoArray');
@@ -173,10 +174,8 @@ function addMathImport(reg, ins) {
   }
   const wParams = params.map(descToWasm);
   const wRet = descToWasm(ret);
-  const jsFn = Math[name];
-  const fn = ret === 'F'
-    ? (...args) => Math.fround(jsFn(...args))
-    : (...args) => jsFn(...args);
+  const fn = mathIntrinsicFunction(name, descriptor);
+  if (!fn) throw new Unsupported(`Math.${name}${descriptor} unsupported`);
   return {
     params: wParams,
     ret: wRet,

--- a/src/jit/wasmShared.js
+++ b/src/jit/wasmShared.js
@@ -250,6 +250,30 @@ const MATH_INTRINSICS = new Set([
   'sqrt', 'pow', 'floor', 'ceil', 'log', 'exp',
 ]);
 
+function mathIntrinsicFunction(name, descriptor) {
+  const { params, ret } = parseMethodDescriptor(descriptor);
+  if (ret === 'J' || params.includes('J')) {
+    // WebAssembly i64 imports receive and return BigInt. JavaScript Math
+    // rejects BigInt, and converting through Number would lose exact long
+    // values. Java Math exposes only these three long overloads.
+    if (name === 'abs' && descriptor === '(J)J') {
+      return (value) => BigInt.asIntN(64, value < 0n ? -value : value);
+    }
+    if (name === 'max' && descriptor === '(JJ)J') {
+      return (left, right) => left > right ? left : right;
+    }
+    if (name === 'min' && descriptor === '(JJ)J') {
+      return (left, right) => left < right ? left : right;
+    }
+    return null;
+  }
+  const jsFn = Math[name];
+  if (typeof jsFn !== 'function') return null;
+  return ret === 'F'
+    ? (...args) => Math.fround(jsFn(...args))
+    : (...args) => jsFn(...args);
+}
+
 // Control-flow exception (per-block demotion, callee-link deferral, whole-
 // method rejection) thrown thousands of times per boot: V8's stack capture in
 // the Error constructor was ~1s of a profiled run, so skip it — nothing ever
@@ -423,6 +447,7 @@ module.exports = {
   NPE, AIOOBE,
   BRANCH_COND, BRANCH_ZERO, ICONST, BIN_OPS, ARRAY_LOAD, ARRAY_STORE,
   MATH_INTRINSICS,
+  mathIntrinsicFunction,
   Unsupported,
   NestedDeopt,
   isGuestThrow,

--- a/src/jre/java/lang/Class.js
+++ b/src/jre/java/lang/Class.js
@@ -13,6 +13,37 @@ function classNameFor(classObj) {
 function runtimeClassName(obj) {
   return obj && (obj._className || obj.type);
 }
+
+function descriptorForClassObject(classObj) {
+  if (!classObj) return '';
+  if (classObj.isPrimitive) {
+    const primitiveDescriptors = {
+      int: 'I',
+      long: 'J',
+      double: 'D',
+      float: 'F',
+      char: 'C',
+      short: 'S',
+      byte: 'B',
+      boolean: 'Z',
+    };
+    const descriptor = primitiveDescriptors[classObj.name];
+    if (descriptor) return descriptor;
+    throw {
+      type: 'java/lang/IllegalArgumentException',
+      message: `Unknown primitive type: ${classObj.name}`,
+    };
+  }
+  const className = classNameFor(classObj);
+  if (!className) {
+    throw {
+      type: 'java/lang/IllegalArgumentException',
+      message: 'Class has no runtime name',
+    };
+  }
+  return className.startsWith('[') ? className : `L${className};`;
+}
+
 const { withThrows } = require('../../helpers');
 
 module.exports = {
@@ -256,29 +287,8 @@ module.exports = {
       const methodName = String(args[0]);
       const paramTypes = args[1];
 
-      const getDescriptor = (paramClass) => {
-        if (!paramClass) return '';
-        if (paramClass.isPrimitive) {
-          switch (paramClass.name) {
-            case 'int': return 'I';
-            case 'long': return 'J';
-            case 'double': return 'D';
-            case 'float': return 'F';
-            case 'char': return 'C';
-            case 'short': return 'S';
-            case 'byte': return 'B';
-            case 'boolean': return 'Z';
-            default:
-              throw {
-                type: 'java/lang/IllegalArgumentException',
-                message: `Unknown primitive type: ${paramClass.name}`,
-              };
-          }
-        }
-        const paramClassName = paramClass._classData.ast.classes[0].className;
-        return `L${paramClassName};`;
-      };
-      const targetDescriptor = `(${paramTypes.map(getDescriptor).join('')})`;
+      const targetDescriptor =
+        `(${paramTypes.map(descriptorForClassObject).join('')})`;
 
       let currentClass = classObj._classData;
       while (currentClass) {
@@ -329,30 +339,8 @@ module.exports = {
       const classData = classObj._classData;
       const methods = classData.ast.classes[0].items.filter(item => item.type === 'method');
 
-      const getDescriptor = (paramClass) => {
-        if (!paramClass) return '';
-        if (paramClass.isPrimitive) {
-          switch (paramClass.name) {
-            case 'int': return 'I';
-            case 'long': return 'J';
-            case 'double': return 'D';
-            case 'float': return 'F';
-            case 'char': return 'C';
-            case 'short': return 'S';
-            case 'byte': return 'B';
-            case 'boolean': return 'Z';
-            default:
-              throw {
-                type: 'java/lang/IllegalArgumentException',
-                message: `Unknown primitive type: ${paramClass.name}`,
-              };
-          }
-        }
-        const paramClassName = paramClass._classData.ast.classes[0].className;
-        return `L${paramClassName};`;
-      };
-
-      const targetDescriptor = `(${paramTypes.map(getDescriptor).join('')})`;
+      const targetDescriptor =
+        `(${paramTypes.map(descriptorForClassObject).join('')})`;
       
       const method = methods.find(m => {
         const d = m.method.descriptor;

--- a/src/jre/java/lang/Class.js
+++ b/src/jre/java/lang/Class.js
@@ -15,7 +15,12 @@ function runtimeClassName(obj) {
 }
 
 function descriptorForClassObject(classObj) {
-  if (!classObj) return '';
+  if (!classObj) {
+    throw {
+      type: 'java/lang/IllegalArgumentException',
+      message: 'Parameter type must not be null',
+    };
+  }
   if (classObj.isPrimitive) {
     const primitiveDescriptors = {
       int: 'I',

--- a/src/jre/java/lang/reflect/Constructor.js
+++ b/src/jre/java/lang/reflect/Constructor.js
@@ -1,20 +1,106 @@
+const Frame = require('../../../../core/frame');
+const { ASYNC_METHOD_SENTINEL } = require('../../../../core/constants');
 const { withThrows } = require('../../../helpers');
+
+function classNameFor(classObj) {
+  return classObj && (classObj.className ||
+    (classObj._classData && (
+      classObj._classData.arrayType ||
+      classObj._classData.className ||
+      (classObj._classData.ast && classObj._classData.ast.classes[0] &&
+        classObj._classData.ast.classes[0].className))));
+}
+
+function descriptorForClass(classObj) {
+  if (classObj && classObj.isPrimitive) {
+    const descriptors = {
+      void: 'V', boolean: 'Z', byte: 'B', char: 'C', short: 'S',
+      int: 'I', long: 'J', float: 'F', double: 'D',
+    };
+    return descriptors[classObj.name] || null;
+  }
+  const className = classNameFor(classObj);
+  if (!className) return null;
+  const normalized = String(className).replace(/\./g, '/');
+  return normalized.startsWith('[') ? normalized : `L${normalized};`;
+}
+
+function constructorDescriptor(constructorObj) {
+  const parameterTypes = constructorObj._parameterTypes || [];
+  const parameters = parameterTypes.map(descriptorForClass);
+  if (parameters.some((descriptor) => !descriptor)) return null;
+  return `(${parameters.join('')})V`;
+}
+
+function unboxConstructorArgument(value) {
+  if (value && typeof value === 'object' && value.value !== undefined &&
+      typeof value.type === 'string' &&
+      value.type.startsWith('java/lang/')) {
+    return value.value;
+  }
+  return value;
+}
 
 module.exports = {
   super: 'java/lang/reflect/AccessibleObject',
   staticFields: {},
   methods: {
-    'newInstance([Ljava/lang/Object;)Ljava/lang/Object;': withThrows((jvm, constructorObj, args) => {
+    'newInstance([Ljava/lang/Object;)Ljava/lang/Object;': withThrows(async (
+      jvm,
+      constructorObj,
+      args,
+      thread,
+    ) => {
       const constructorArgs = args[0] || [];
       if (typeof constructorObj._newInstance === 'function') {
         return constructorObj._newInstance(jvm, constructorArgs);
       }
       const declaringClass = constructorObj._declaringClass;
-      const className = declaringClass && (declaringClass.className
-        || (declaringClass._classData && declaringClass._classData.ast
-          && declaringClass._classData.ast.classes[0].className));
+      const className = classNameFor(declaringClass);
       if (!className) throw { type: 'java/lang/InstantiationException' };
-      return { type: String(className).replace(/\./g, '/'), constructorArgs };
+      const normalizedClassName = String(className).replace(/\./g, '/');
+      const descriptor = constructorDescriptor(constructorObj);
+      if (!descriptor) {
+        throw {
+          type: 'java/lang/IllegalArgumentException',
+          message: 'Could not resolve reflective constructor parameter types',
+        };
+      }
+      const activeThread = thread ||
+        jvm.threads[jvm.currentThreadIndex] ||
+        jvm.threads[0];
+      const newObj = await jvm.createAppletInstance(
+        normalizedClassName,
+        activeThread,
+      );
+      const constructor = jvm.findMethod(
+        jvm.classes[normalizedClassName],
+        '<init>',
+        descriptor,
+      );
+      if (!constructor) {
+        throw {
+          type: 'java/lang/InstantiationException',
+          message: `${normalizedClassName}.${descriptor}`,
+        };
+      }
+
+      const callingFrame = activeThread.callStack.peek();
+      const constructorFrame = new Frame(constructor);
+      constructorFrame.className = normalizedClassName;
+      constructorFrame.locals[0] = newObj;
+      let localIndex = 1;
+      for (const argument of constructorArgs) {
+        constructorFrame.locals[localIndex++] =
+          unboxConstructorArgument(argument);
+      }
+      activeThread.isAwaitingReflectiveCall = true;
+      activeThread.reflectiveCallFrame = constructorFrame;
+      activeThread.reflectiveCallResolver = () => {
+        callingFrame.stack.push(newObj);
+      };
+      activeThread.callStack.push(constructorFrame);
+      return ASYNC_METHOD_SENTINEL;
     }, [
       'java/lang/InstantiationException',
       'java/lang/IllegalAccessException',

--- a/src/jre/java/lang/reflect/Constructor.js
+++ b/src/jre/java/lang/reflect/Constructor.js
@@ -1,6 +1,10 @@
 const Frame = require('../../../../core/frame');
 const { ASYNC_METHOD_SENTINEL } = require('../../../../core/constants');
 const { withThrows } = require('../../../helpers');
+const { parseDescriptor } = require('../../../../parsing/typeParser');
+const {
+  assignReflectiveArguments,
+} = require('../../../../core/reflectionArguments');
 
 function classNameFor(classObj) {
   return classObj && (classObj.className ||
@@ -30,15 +34,6 @@ function constructorDescriptor(constructorObj) {
   const parameters = parameterTypes.map(descriptorForClass);
   if (parameters.some((descriptor) => !descriptor)) return null;
   return `(${parameters.join('')})V`;
-}
-
-function unboxConstructorArgument(value) {
-  if (value && typeof value === 'object' && value.value !== undefined &&
-      typeof value.type === 'string' &&
-      value.type.startsWith('java/lang/')) {
-    return value.value;
-  }
-  return value;
 }
 
 module.exports = {
@@ -73,8 +68,16 @@ module.exports = {
         normalizedClassName,
         activeThread,
       );
+      const classData = newObj && newObj._classData ||
+        jvm.classes[normalizedClassName];
+      if (!classData) {
+        throw {
+          type: 'java/lang/InstantiationException',
+          message: `${normalizedClassName}.${descriptor}`,
+        };
+      }
       const constructor = jvm.findMethod(
-        jvm.classes[normalizedClassName],
+        classData,
         '<init>',
         descriptor,
       );
@@ -89,15 +92,16 @@ module.exports = {
       const constructorFrame = new Frame(constructor);
       constructorFrame.className = normalizedClassName;
       constructorFrame.locals[0] = newObj;
-      let localIndex = 1;
-      for (const argument of constructorArgs) {
-        constructorFrame.locals[localIndex++] =
-          unboxConstructorArgument(argument);
-      }
+      assignReflectiveArguments(
+        constructorFrame.locals,
+        constructorArgs,
+        parseDescriptor(descriptor).params,
+        1,
+      );
       activeThread.isAwaitingReflectiveCall = true;
       activeThread.reflectiveCallFrame = constructorFrame;
       activeThread.reflectiveCallResolver = () => {
-        callingFrame.stack.push(newObj);
+        if (callingFrame) callingFrame.stack.push(newObj);
       };
       activeThread.callStack.push(constructorFrame);
       return ASYNC_METHOD_SENTINEL;

--- a/src/jre/java/lang/reflect/Method.js
+++ b/src/jre/java/lang/reflect/Method.js
@@ -28,6 +28,28 @@ function boxReflectiveReturn(descriptor, value) {
   }
 }
 
+function unboxReflectiveArgument(parameterType, value) {
+  const boxedValue = value && typeof value === 'object' &&
+    Object.prototype.hasOwnProperty.call(value, 'value')
+    ? value.value : value;
+  switch (parameterType) {
+    case 'boolean': return boxedValue ? 1 : 0;
+    case 'byte':
+    case 'short':
+    case 'char':
+    case 'int':
+      return Number(boxedValue) | 0;
+    case 'long':
+      return typeof boxedValue === 'bigint'
+        ? boxedValue : BigInt(Math.trunc(Number(boxedValue)));
+    case 'float':
+    case 'double':
+      return Number(boxedValue);
+    default:
+      return value;
+  }
+}
+
 const MODIFIERS = {
   PUBLIC: 0x00000001,
   PRIVATE: 0x00000002,
@@ -121,8 +143,11 @@ module.exports = {
         newFrame.locals[localIndex++] = obj;
       }
       if (methodArgs) {
-        for (const arg of methodArgs) {
-          newFrame.locals[localIndex++] = arg;
+        for (let index = 0; index < methodArgs.length; index += 1) {
+          newFrame.locals[localIndex] =
+            unboxReflectiveArgument(params[index], methodArgs[index]);
+          localIndex += params[index] === 'long' || params[index] === 'double'
+            ? 2 : 1;
         }
       }
 
@@ -130,6 +155,7 @@ module.exports = {
       const callingFrame = thread.callStack.peek();
 
       thread.isAwaitingReflectiveCall = true;
+      thread.reflectiveCallFrame = newFrame;
       // Return bytecodes hand the resolver a concrete JVM value. Keep this
       // synchronous so the fast interpreter cannot resume the caller before
       // its reflected result has been materialized.

--- a/src/jre/java/lang/reflect/Method.js
+++ b/src/jre/java/lang/reflect/Method.js
@@ -2,6 +2,9 @@ const Frame = require('../../../../core/frame');
 const { parseDescriptor } = require('../../../../parsing/typeParser');
 const { ASYNC_METHOD_SENTINEL } = require('../../../../core/constants');
 const { withThrows } = require('../../../helpers');
+const {
+  assignReflectiveArguments,
+} = require('../../../../core/reflectionArguments');
 
 // Method.invoke must return boxed objects for primitive-returning methods;
 // callers checkcast to the wrapper type (e.g. (Long) m.invoke(...)).
@@ -25,28 +28,6 @@ function boxReflectiveReturn(descriptor, value) {
     case 'F': return box('java/lang/Float', Number(value));
     case 'D': return box('java/lang/Double', Number(value));
     default: return value;
-  }
-}
-
-function unboxReflectiveArgument(parameterType, value) {
-  const boxedValue = value && typeof value === 'object' &&
-    Object.prototype.hasOwnProperty.call(value, 'value')
-    ? value.value : value;
-  switch (parameterType) {
-    case 'boolean': return boxedValue ? 1 : 0;
-    case 'byte':
-    case 'short':
-    case 'char':
-    case 'int':
-      return Number(boxedValue) | 0;
-    case 'long':
-      return typeof boxedValue === 'bigint'
-        ? boxedValue : BigInt(Math.trunc(Number(boxedValue)));
-    case 'float':
-    case 'double':
-      return Number(boxedValue);
-    default:
-      return value;
   }
 }
 
@@ -143,12 +124,9 @@ module.exports = {
         newFrame.locals[localIndex++] = obj;
       }
       if (methodArgs) {
-        for (let index = 0; index < methodArgs.length; index += 1) {
-          newFrame.locals[localIndex] =
-            unboxReflectiveArgument(params[index], methodArgs[index]);
-          localIndex += params[index] === 'long' || params[index] === 'double'
-            ? 2 : 1;
-        }
+        assignReflectiveArguments(
+          newFrame.locals, methodArgs, params, localIndex,
+        );
       }
 
       const thread = jvm.threads[jvm.currentThreadIndex];
@@ -160,7 +138,9 @@ module.exports = {
       // synchronous so the fast interpreter cannot resume the caller before
       // its reflected result has been materialized.
       thread.reflectiveCallResolver = (ret) => {
-        callingFrame.stack.push(boxReflectiveReturn(descriptor, ret));
+        if (callingFrame) {
+          callingFrame.stack.push(boxReflectiveReturn(descriptor, ret));
+        }
       };
       thread.callStack.push(newFrame);
 

--- a/src/jre/javax/sound/sampled/SourceDataLine.js
+++ b/src/jre/javax/sound/sampled/SourceDataLine.js
@@ -74,7 +74,7 @@ module.exports = {
       const self = jvm.jre["javax/sound/sampled/SourceDataLine"];
       self.methods["open(Ljavax/sound/sampled/AudioFormat;)V"](jvm, obj, args);
     },
-    "write([BII)I": withThrows((jvm, obj, args) => {
+    "write([BII)I": withThrows((jvm, obj, args, thread) => {
       const [buffer, offset, len] = args;
 
       if (!obj.audioOutput || !obj.isOpen) {
@@ -86,6 +86,15 @@ module.exports = {
 
       try {
         obj.audioOutput.write(toAudioBytes(buffer, offset, len));
+        if (thread && obj.audioOutput &&
+            typeof obj.audioOutput.queuedSeconds === "function" &&
+            obj.audioOutput.queuedSeconds() < 0.04) {
+          jvm._audioPriority = {
+            thread,
+            output: obj.audioOutput,
+            until: Date.now() + 50,
+          };
+        }
         return len;
       } catch (error) {
         console.error("Audio write error:", error.message);

--- a/src/jre/javax/sound/sampled/SourceDataLine.js
+++ b/src/jre/javax/sound/sampled/SourceDataLine.js
@@ -92,7 +92,7 @@ module.exports = {
           jvm._audioPriority = {
             thread,
             output: obj.audioOutput,
-            until: Date.now() + 50,
+            until: jvm.clock.millis() + 50,
           };
         }
         return len;

--- a/src/platform/browser-entry.js
+++ b/src/platform/browser-entry.js
@@ -239,6 +239,12 @@ class BrowserJVMDebug {
       console.error('Failed to run class:', error);
       const wrapped = new Error(`Run failed: ${thrownValueMessage(error)}`);
       wrapped.cause = error;
+      if (error && typeof error.stack === 'string') {
+        wrapped.causeStack = error.stack;
+      }
+      if (error && error.jvmGuestLocation) {
+        wrapped.jvmGuestLocation = error.jvmGuestLocation;
+      }
       if (error && typeof error.type === 'string') {
         wrapped.jvmExceptionType = error.type;
         wrapped.jvmExceptionMessage = thrownValueMessage(error);

--- a/src/platform/web-audio.js
+++ b/src/platform/web-audio.js
@@ -4,6 +4,7 @@
   }
 
   let sharedAudioContext = null;
+  let sharedWorkletReady = null;
   let resumeListenersInstalled = false;
   let outputCount = 0;
   let closedOutputCount = 0;
@@ -14,7 +15,105 @@
   let peakSampledAmplitude = 0;
   let underrunCount = 0;
   let underrunSeconds = 0;
+  let scheduledBufferCount = 0;
+  let coalescedWriteCount = 0;
+  let boundaryJumpCount = 0;
+  let boundaryJumpTotal = 0;
+  let boundaryJumpMaximum = 0;
+  let saturatedSampleCount = 0;
   const activeOutputs = new Set();
+  const forceMonoByQuery = Boolean(global.location &&
+    typeof global.location.search === "string" &&
+    new URLSearchParams(global.location.search).get("audio") === "mono");
+  const WORKLET_SOURCE = `
+class JVMSourceDataLineProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const config = options.processorOptions || {};
+    this.channels = Math.max(1, config.channels || 1);
+    this.inputRate = Math.max(1, config.sampleRate || sampleRate);
+    this.ratio = this.inputRate / sampleRate;
+    this.startFrames = Math.max(1, config.startFrames || 2048);
+    this.chunks = [];
+    this.chunkOffset = 0;
+    this.queuedFrames = 0;
+    this.phase = 0;
+    this.current = null;
+    this.next = null;
+    this.started = false;
+    this.generation = 0;
+    this.reportCountdown = 0;
+    this.port.onmessage = event => {
+      const message = event.data || {};
+      if (message.type === "pcm" && message.generation === this.generation) {
+        this.chunks.push(new Float32Array(message.samples));
+        this.queuedFrames += message.frames || 0;
+      } else if (message.type === "flush") {
+        this.generation = message.generation;
+        this.chunks.length = 0;
+        this.chunkOffset = 0;
+        this.queuedFrames = 0;
+        this.current = this.next = null;
+        this.started = false;
+        this.phase = 0;
+      }
+    };
+  }
+  readFrame() {
+    while (this.chunks.length) {
+      const chunk = this.chunks[0];
+      if (this.chunkOffset + this.channels <= chunk.length) {
+        const frame = new Float32Array(this.channels);
+        for (let channel = 0; channel < this.channels; channel++)
+          frame[channel] = chunk[this.chunkOffset + channel];
+        this.chunkOffset += this.channels;
+        this.queuedFrames = Math.max(0, this.queuedFrames - 1);
+        if (this.chunkOffset >= chunk.length) {
+          this.chunks.shift();
+          this.chunkOffset = 0;
+        }
+        return frame;
+      }
+      this.chunks.shift();
+      this.chunkOffset = 0;
+    }
+    return null;
+  }
+  process(inputs, outputs) {
+    const output = outputs[0];
+    if (!this.started && this.queuedFrames >= this.startFrames) {
+      this.current = this.readFrame();
+      this.next = this.readFrame();
+      this.started = Boolean(this.current && this.next);
+    }
+    for (let frame = 0; frame < output[0].length; frame++) {
+      if (!this.started || !this.current || !this.next) break;
+      for (let channel = 0; channel < output.length; channel++) {
+        const sourceChannel = Math.min(channel, this.channels - 1);
+        output[channel][frame] = this.current[sourceChannel] +
+          (this.next[sourceChannel] - this.current[sourceChannel]) * this.phase;
+      }
+      this.phase += this.ratio;
+      while (this.phase >= 1) {
+        this.phase -= 1;
+        this.current = this.next;
+        this.next = this.readFrame();
+        if (!this.next) {
+          this.port.postMessage({type: "underrun"});
+          this.started = false;
+          this.current = null;
+          break;
+        }
+      }
+    }
+    if (--this.reportCountdown <= 0) {
+      this.reportCountdown = 16;
+      this.port.postMessage({type: "queue", frames: this.queuedFrames});
+    }
+    return true;
+  }
+}
+registerProcessor("jvm-source-data-line", JVMSourceDataLineProcessor);`;
 
   function resumeSharedAudioContext() {
     const context = getAudioContext();
@@ -45,6 +144,14 @@
     }
     if (!sharedAudioContext || sharedAudioContext.state === "closed") {
       sharedAudioContext = new AudioContextCtor();
+      if (sharedAudioContext.audioWorklet && global.AudioWorkletNode &&
+          global.Blob && global.URL &&
+          typeof global.URL.createObjectURL === "function") {
+        const url = global.URL.createObjectURL(new global.Blob(
+          [WORKLET_SOURCE], { type: "text/javascript" }));
+        sharedWorkletReady = sharedAudioContext.audioWorklet.addModule(url)
+          .finally(() => global.URL.revokeObjectURL(url));
+      }
       installResumeListeners();
     }
     return sharedAudioContext;
@@ -65,6 +172,89 @@
       this.bufferSize = Math.max(1, Number(options.bufferSize) || 4096);
       this.bytesPerFrame = Math.max(1, options.channels || 1) *
         Math.max(1, (options.bitDepth || 16) / 8);
+      // SourceDataLine is a continuous stream. Scheduling every 256-frame
+      // guest write as an independent 22.05 kHz AudioBufferSource makes the
+      // browser restart its sample-rate converter at every tiny boundary.
+      // Preserve larger continuous regions before handing them to WebAudio.
+      const capacityFrames = Math.max(1,
+        Math.floor(this.bufferSize / this.bytesPerFrame));
+      this.coalesceFrames = Math.max(1,
+        Number(options.coalesceFrames) ||
+        Math.min(2048, Math.max(256, Math.floor(capacityFrames / 4))));
+      this.coalesceDelayMs = Math.max(0,
+        Number.isFinite(Number(options.coalesceDelayMs))
+          ? Number(options.coalesceDelayMs)
+          : 100);
+      this.stagedChunks = [];
+      this.stagedByteLength = 0;
+      this.stagedFrames = 0;
+      this.stageTimer = null;
+      this.lastSamples = new Array(Math.max(1, options.channels || 1)).fill(null);
+      this.channelAbsoluteSums =
+        new Array(Math.max(1, options.channels || 1)).fill(0);
+      this.channelDifferenceSums =
+        new Array(Math.max(1, options.channels || 1)).fill(0);
+      this.channelPcmChecksums =
+        new Array(Math.max(1, options.channels || 1)).fill(0);
+      this.channelContentPcmChecksums =
+        new Array(Math.max(1, options.channels || 1)).fill(0);
+      this.pcmChecksum = 0;
+      this.contentPcmChecksum = 0;
+      this.pcmRecordedFrames = 0;
+      this.contentFrames = 0;
+      this.firstNonSilentFrame = null;
+      this.decodedFrames = 0;
+      this.underruns = 0;
+      this.underrunSeconds = 0;
+      this.forceMono = options.forceMono === true || forceMonoByQuery;
+      this.workletNode = null;
+      this.workletQueuedFrames = 0;
+      this.workletGeneration = 0;
+      // Long-lived music benefits from an ~80 ms cushion, but short-lived
+      // effect lines often contain only one coalesced region. Requiring the
+      // music-sized cushion there means valid transient PCM is queued but the
+      // processor never starts. Keep the threshold no larger than the first
+      // region the line naturally publishes (and at least two frames for the
+      // linear interpolator).
+      this.workletStartFrames = Math.max(2, Math.min(
+        this.coalesceFrames,
+        Math.round((this.options.sampleRate || 44100) * 0.08),
+      ));
+      if (sharedWorkletReady) {
+        sharedWorkletReady.then(() => {
+          if (this.closed) return;
+          const playbackChannels =
+            this.forceMono && (this.options.channels || 1) > 1
+              ? 1 : Math.max(1, this.options.channels || 1);
+          this.workletNode = new global.AudioWorkletNode(
+            this.context, "jvm-source-data-line", {
+              numberOfInputs: 0,
+              numberOfOutputs: 1,
+              outputChannelCount: [playbackChannels],
+              processorOptions: {
+                channels: playbackChannels,
+                sampleRate: this.options.sampleRate,
+                startFrames: this.workletStartFrames,
+              },
+            });
+          this.workletNode.port.onmessage = event => {
+            if (event.data && event.data.type === "queue") {
+              this.workletQueuedFrames = Math.max(0,
+                Number(event.data.frames) || 0);
+            } else if (event.data && event.data.type === "underrun") {
+              this.underruns += 1;
+              underrunCount += 1;
+            }
+          };
+          this.workletNode.connect(this.context.destination);
+          this.scheduleStaged();
+        }).catch(() => {
+          sharedWorkletReady = null;
+          this.scheduleStaged();
+        });
+      }
+      this.guestWrites = 0;
+      this.scheduledBuffers = 0;
       this.closed = false;
       this.hasScheduledAudio = false;
       activeOutputs.add(this);
@@ -86,19 +276,198 @@
       }
       writeCount += 1;
       writtenFrames += frameCount;
+      this.guestWrites += 1;
 
       if (this.context.state === "suspended" && typeof this.context.resume === "function") {
         resumeSharedAudioContext();
       }
+      this.stagedChunks.push(bytes);
+      this.stagedByteLength += bytes.length;
+      this.stagedFrames += frameCount;
+      if (this.stagedFrames >= this.coalesceFrames) {
+        this.scheduleStaged();
+      } else if (this.stageTimer === null && this.coalesceDelayMs > 0) {
+        this.stageTimer = setTimeout(() => {
+          this.stageTimer = null;
+          if (!this.closed) this.scheduleStaged();
+        }, this.coalesceDelayMs);
+      }
+    }
 
+    scheduleStaged() {
+      if (this.stageTimer !== null) {
+        clearTimeout(this.stageTimer);
+        this.stageTimer = null;
+      }
+      if (this.stagedByteLength <= 0) {
+        return;
+      }
+      if (sharedWorkletReady && !this.workletNode) return;
+      const bytes = new Uint8Array(this.stagedByteLength);
+      let byteOffset = 0;
+      for (const chunk of this.stagedChunks) {
+        bytes.set(chunk, byteOffset);
+        byteOffset += chunk.length;
+      }
+      const representedWrites = this.stagedChunks.length;
+      this.stagedChunks = [];
+      this.stagedByteLength = 0;
+      this.stagedFrames = 0;
+      if (representedWrites > 1) {
+        coalescedWriteCount += representedWrites - 1;
+      }
+      this.recordPcmBytes(bytes);
+      if (this.workletNode) this.scheduleWorkletBytes(bytes);
+      else this.scheduleBytes(bytes);
+    }
+
+    recordPcmBytes(bytes) {
+      const channels = Math.max(1, this.options.channels || 1);
+      const bitDepth = this.options.bitDepth || 16;
+      const bytesPerSample = (this.options.bitDepth || 16) / 8;
+      const frameCount =
+        Math.floor(bytes.length / (channels * bytesPerSample));
+      for (let frame = 0; frame < frameCount; frame += 1) {
+        let hasSignal = false;
+        for (let channel = 0; channel < channels; channel += 1) {
+          const sampleIndex =
+            (frame * channels + channel) * bytesPerSample;
+          if (bitDepth === 8) {
+            const silence = this.options.signed !== false ? 0 : 128;
+            hasSignal ||= (bytes[sampleIndex] & 0xff) !== silence;
+          } else {
+            const first = bytes[sampleIndex] & 0xff;
+            const second = bytes[sampleIndex + 1] & 0xff;
+            const raw = this.options.bigEndian === true
+              ? (first << 8) | second : first | (second << 8);
+            const silence = this.options.signed !== false ? 0 : 32768;
+            hasSignal ||= raw !== silence;
+          }
+        }
+        if (this.firstNonSilentFrame === null && hasSignal) {
+          this.firstNonSilentFrame = this.pcmRecordedFrames + frame;
+        }
+        const contentStarted = this.firstNonSilentFrame !== null;
+        for (let channel = 0; channel < channels; channel += 1) {
+          const sampleIndex =
+            (frame * channels + channel) * bytesPerSample;
+          for (let byte = 0; byte < bytesPerSample; byte += 1) {
+            const signedByte = signed8(bytes[sampleIndex + byte] & 0xff);
+            this.pcmChecksum =
+              (Math.imul(this.pcmChecksum, 31) + signedByte) | 0;
+            this.channelPcmChecksums[channel] = (
+              Math.imul(this.channelPcmChecksums[channel], 31) + signedByte
+            ) | 0;
+            if (contentStarted) {
+              this.contentPcmChecksum = (
+                Math.imul(this.contentPcmChecksum, 31) + signedByte
+              ) | 0;
+              this.channelContentPcmChecksums[channel] = (
+                Math.imul(this.channelContentPcmChecksums[channel], 31) +
+                signedByte
+              ) | 0;
+            }
+          }
+        }
+        if (contentStarted) this.contentFrames += 1;
+      }
+      this.pcmRecordedFrames += frameCount;
+    }
+
+    scheduleWorkletBytes(bytes) {
+      const channels = Math.max(1, this.options.channels || 1);
+      const bitDepth = this.options.bitDepth || 16;
+      const bytesPerSample = bitDepth / 8;
+      const frames = Math.floor(bytes.length / (channels * bytesPerSample));
+      const playbackChannels = this.forceMono && channels > 1 ? 1 : channels;
+      const samples = new Float32Array(frames * playbackChannels);
+      for (let frame = 0; frame < frames; frame++) {
+        if (playbackChannels === 1 && channels > 1) {
+          let sum = 0;
+          for (let channel = 0; channel < channels; channel++) {
+            const sampleIndex =
+              (frame * channels + channel) * bytesPerSample;
+            const sample = decodePcmSample(bytes,
+              sampleIndex, bitDepth,
+              this.options.signed !== false, this.options.bigEndian === true);
+            sum += sample;
+            const amplitude = Math.abs(sample);
+            if (amplitude >= 1) saturatedSampleCount += 1;
+            this.channelAbsoluteSums[channel] += amplitude;
+            if (frame === 0 && this.lastSamples[channel] !== null) {
+              const jump = Math.abs(sample - this.lastSamples[channel]);
+              boundaryJumpCount += 1;
+              boundaryJumpTotal += jump;
+              boundaryJumpMaximum = Math.max(boundaryJumpMaximum, jump);
+            }
+            if (this.lastSamples[channel] !== null) {
+              this.channelDifferenceSums[channel] +=
+                Math.abs(sample - this.lastSamples[channel]);
+            }
+            this.lastSamples[channel] = sample;
+          }
+          samples[frame] = sum / channels;
+        } else {
+          for (let channel = 0; channel < channels; channel++) {
+            const sampleIndex =
+              (frame * channels + channel) * bytesPerSample;
+            const sample = decodePcmSample(bytes,
+              sampleIndex, bitDepth,
+              this.options.signed !== false, this.options.bigEndian === true);
+            samples[frame * channels + channel] = sample;
+            const amplitude = Math.abs(sample);
+            if (amplitude >= 1) saturatedSampleCount += 1;
+            this.channelAbsoluteSums[channel] += amplitude;
+            if (frame === 0 && this.lastSamples[channel] !== null) {
+              const jump = Math.abs(sample - this.lastSamples[channel]);
+              boundaryJumpCount += 1;
+              boundaryJumpTotal += jump;
+              boundaryJumpMaximum = Math.max(boundaryJumpMaximum, jump);
+            }
+            if (this.lastSamples[channel] !== null) {
+              this.channelDifferenceSums[channel] +=
+                Math.abs(sample - this.lastSamples[channel]);
+            }
+            this.lastSamples[channel] = sample;
+          }
+        }
+        if (frame % 128 === 0) {
+          const diagnosticSample = samples[frame * playbackChannels];
+          const amplitude = Math.abs(diagnosticSample);
+          sampledFrames += 1;
+          if (amplitude > 1 / 32768) nonSilentSampledFrames += 1;
+          if (amplitude > peakSampledAmplitude) {
+            peakSampledAmplitude = amplitude;
+          }
+        }
+      }
+      this.decodedFrames += frames;
+      this.workletQueuedFrames += frames;
+      this.workletNode.port.postMessage({
+        type: "pcm", generation: this.workletGeneration, frames,
+        samples: samples.buffer,
+      }, [samples.buffer]);
+    }
+
+    scheduleBytes(bytes) {
+      const channels = Math.max(1, this.options.channels || 1);
+      const bitDepth = this.options.bitDepth || 16;
+      const bytesPerSample = bitDepth / 8;
+      const frameCount = Math.floor(bytes.length / (bytesPerSample * channels));
+      if (frameCount <= 0) return;
+      const playbackChannels = this.forceMono && channels > 1 ? 1 : channels;
       const audioBuffer = this.context.createBuffer(
-        channels,
+        playbackChannels,
         frameCount,
         this.options.sampleRate || this.context.sampleRate || 44100,
       );
 
+      const decodedChannels = new Array(channels);
       for (let channel = 0; channel < channels; channel += 1) {
-        const channelData = audioBuffer.getChannelData(channel);
+        const channelData = playbackChannels === channels
+          ? audioBuffer.getChannelData(channel)
+          : new Float32Array(frameCount);
+        decodedChannels[channel] = channelData;
         for (let frame = 0; frame < frameCount; frame += 1) {
           const sampleIndex = (frame * channels + channel) * bytesPerSample;
           channelData[frame] = decodePcmSample(
@@ -108,8 +477,33 @@
             this.options.signed !== false,
             this.options.bigEndian === true,
           );
+          const amplitude = Math.abs(channelData[frame]);
+          if (amplitude >= 1) saturatedSampleCount += 1;
+          this.channelAbsoluteSums[channel] += amplitude;
+          if (frame === 0 && this.lastSamples[channel] !== null) {
+            const jump = Math.abs(channelData[frame] - this.lastSamples[channel]);
+            boundaryJumpCount += 1;
+            boundaryJumpTotal += jump;
+            boundaryJumpMaximum = Math.max(boundaryJumpMaximum, jump);
+          }
+          if (this.lastSamples[channel] !== null) {
+            this.channelDifferenceSums[channel] +=
+              Math.abs(channelData[frame] - this.lastSamples[channel]);
+          }
+          this.lastSamples[channel] = channelData[frame];
         }
       }
+      if (playbackChannels === 1 && channels > 1) {
+        const mono = audioBuffer.getChannelData(0);
+        for (let frame = 0; frame < frameCount; frame += 1) {
+          let value = 0;
+          for (let channel = 0; channel < channels; channel += 1) {
+            value += decodedChannels[channel][frame];
+          }
+          mono[frame] = value / channels;
+        }
+      }
+      this.decodedFrames += frameCount;
       // Sample the already-decoded signal sparsely. This is diagnostics, not
       // a second full PCM pass through a hot audio loop.
       const diagnosticChannel = audioBuffer.getChannelData(0);
@@ -129,6 +523,8 @@
       source.connect(this.context.destination);
       this.pendingSources += 1;
       this.sources.add(source);
+      this.scheduledBuffers += 1;
+      scheduledBufferCount += 1;
       source.onended = () => {
         if (!this.sources.delete(source)) {
           return;
@@ -141,8 +537,11 @@
 
       const now = this.context.currentTime;
       if (this.hasScheduledAudio && this.scheduledTime < now) {
+        const gap = now - this.scheduledTime;
         underrunCount += 1;
-        underrunSeconds += now - this.scheduledTime;
+        underrunSeconds += gap;
+        this.underruns += 1;
+        this.underrunSeconds += gap;
       }
       const startTime = Math.max(now, this.scheduledTime);
       source.start(startTime);
@@ -157,9 +556,11 @@
       const sampleRate = this.options.sampleRate ||
         this.context.sampleRate ||
         44100;
-      const queuedFrames = Math.ceil(
-        Math.max(0, this.scheduledTime - this.context.currentTime) * sampleRate,
-      );
+      const queuedFrames = this.workletNode
+        ? this.workletQueuedFrames + this.stagedFrames
+        : Math.ceil(
+          Math.max(0, this.scheduledTime - this.context.currentTime) * sampleRate,
+        ) + this.stagedFrames;
       return Math.max(0,
         this.bufferSize - queuedFrames * this.bytesPerFrame);
     }
@@ -168,6 +569,7 @@
       if (event !== "drain") {
         return;
       }
+      this.scheduleStaged();
       if (this.pendingSources === 0) {
         setTimeout(callback, 0);
       } else {
@@ -181,10 +583,31 @@
     }
 
     queuedSeconds() {
-      return Math.max(0, this.scheduledTime - this.context.currentTime);
+      const sampleRate = this.options.sampleRate ||
+        this.context.sampleRate ||
+        44100;
+      if (this.workletNode) {
+        return (this.workletQueuedFrames + this.stagedFrames) / sampleRate;
+      }
+      return Math.max(0, this.scheduledTime - this.context.currentTime) +
+        this.stagedFrames / sampleRate;
     }
 
     flush() {
+      if (this.stageTimer !== null) {
+        clearTimeout(this.stageTimer);
+        this.stageTimer = null;
+      }
+      this.stagedChunks = [];
+      this.stagedByteLength = 0;
+      this.stagedFrames = 0;
+      if (this.workletNode) {
+        this.workletGeneration += 1;
+        this.workletQueuedFrames = 0;
+        this.workletNode.port.postMessage({
+          type: "flush", generation: this.workletGeneration,
+        });
+      }
       for (const source of this.sources) {
         source.onended = null;
         if (typeof source.stop === "function") {
@@ -206,6 +629,9 @@
         return;
       }
       this.flush();
+      if (this.workletNode && typeof this.workletNode.disconnect === "function") {
+        this.workletNode.disconnect();
+      }
       this.closed = true;
       activeOutputs.delete(this);
       closedOutputCount += 1;
@@ -214,12 +640,12 @@
 
   function toByteArray(data) {
     if (data == null) {
-      return [];
+      return new Uint8Array(0);
     }
     if (ArrayBuffer.isView(data)) {
-      return Array.from(data);
+      return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
     }
-    return Array.from(data, (value) => value & 0xff);
+    return Uint8Array.from(data, (value) => value & 0xff);
   }
 
   function decodePcmSample(bytes, index, bitDepth, signed, bigEndian) {
@@ -275,8 +701,60 @@
       peakSampledAmplitude: Math.round(peakSampledAmplitude * 1000000) / 1000000,
       underruns: underrunCount,
       underrunSeconds: Math.round(underrunSeconds * 1000) / 1000,
+      scheduledBuffers: scheduledBufferCount,
+      coalescedWrites: coalescedWriteCount,
+      boundaryJumps: boundaryJumpCount,
+      averageBoundaryJump: boundaryJumpCount
+        ? Math.round(boundaryJumpTotal / boundaryJumpCount * 1000000) / 1000000
+        : 0,
+      maximumBoundaryJump:
+        Math.round(boundaryJumpMaximum * 1000000) / 1000000,
+      saturatedSamples: saturatedSampleCount,
       queuedSeconds: Math.round(queuedSeconds * 1000) / 1000,
       maxOutputQueueSeconds: Math.round(maxOutputQueueSeconds * 1000) / 1000,
+      outputFormats: [...activeOutputs].map((output) => ({
+        sampleRate: output.options.sampleRate,
+        channels: output.options.channels,
+        bitDepth: output.options.bitDepth,
+        signed: output.options.signed,
+        bigEndian: output.options.bigEndian,
+        bufferSize: output.bufferSize,
+        playbackChannels:
+          output.forceMono && output.options.channels > 1
+            ? 1
+            : output.options.channels,
+        forceMono: output.forceMono,
+        backend: output.workletNode ? "audio-worklet" : "buffer-sources",
+        coalesceFrames: output.coalesceFrames,
+        coalesceDelayMs: output.coalesceDelayMs,
+        workletStartFrames: output.workletStartFrames,
+        guestWrites: output.guestWrites,
+        scheduledBuffers: output.scheduledBuffers,
+        stagedFrames: output.stagedFrames,
+        queuedSeconds:
+          Math.round(output.queuedSeconds() * 1000) / 1000,
+        underruns: output.underruns,
+        underrunSeconds:
+          Math.round(output.underrunSeconds * 1000) / 1000,
+        decodedFrames: output.decodedFrames,
+        pcmChecksum: output.pcmChecksum >>> 0,
+        channelPcmChecksums:
+          output.channelPcmChecksums.map((checksum) => checksum >>> 0),
+        firstNonSilentFrame: output.firstNonSilentFrame,
+        contentFrames: output.contentFrames,
+        contentPcmChecksum: output.contentPcmChecksum >>> 0,
+        channelContentPcmChecksums:
+          output.channelContentPcmChecksums.map(
+            (checksum) => checksum >>> 0),
+        channelAverageAmplitude: output.channelAbsoluteSums.map((sum) =>
+          output.decodedFrames
+            ? Math.round(sum / output.decodedFrames * 1000000) / 1000000
+            : 0),
+        channelAverageDifference: output.channelDifferenceSums.map((sum) =>
+          output.decodedFrames
+            ? Math.round(sum / output.decodedFrames * 1000000) / 1000000
+            : 0),
+      })),
     };
   };
   global.JVMDebug.audioPlatform.setAudioOutputFactory((options) => new WebAudioOutput(options));

--- a/src/platform/web-audio.js
+++ b/src/platform/web-audio.js
@@ -241,6 +241,7 @@ registerProcessor("jvm-source-data-line", JVMSourceDataLineProcessor);`;
             if (event.data && event.data.type === "queue") {
               this.workletQueuedFrames = Math.max(0,
                 Number(event.data.frames) || 0);
+              this.maybeFlushDrainCallbacks();
             } else if (event.data && event.data.type === "underrun") {
               this.underruns += 1;
               underrunCount += 1;
@@ -281,7 +282,9 @@ registerProcessor("jvm-source-data-line", JVMSourceDataLineProcessor);`;
       if (this.context.state === "suspended" && typeof this.context.resume === "function") {
         resumeSharedAudioContext();
       }
-      this.stagedChunks.push(bytes);
+      // Staging outlives the guest write call, whose backing byte array may
+      // be reused immediately for the next mixer region.
+      this.stagedChunks.push(new Uint8Array(bytes));
       this.stagedByteLength += bytes.length;
       this.stagedFrames += frameCount;
       if (this.stagedFrames >= this.coalesceFrames) {
@@ -570,11 +573,15 @@ registerProcessor("jvm-source-data-line", JVMSourceDataLineProcessor);`;
         return;
       }
       this.scheduleStaged();
-      if (this.pendingSources === 0) {
-        setTimeout(callback, 0);
-      } else {
-        this.drainCallbacks.push(callback);
-      }
+      this.drainCallbacks.push(callback);
+      this.maybeFlushDrainCallbacks();
+    }
+
+    maybeFlushDrainCallbacks() {
+      const drained = this.workletNode
+        ? this.stagedFrames === 0 && this.workletQueuedFrames === 0
+        : this.pendingSources === 0;
+      if (drained) this.flushDrainCallbacks();
     }
 
     flushDrainCallbacks() {

--- a/test/browserEntryErrors.test.js
+++ b/test/browserEntryErrors.test.js
@@ -55,3 +55,34 @@ test('thrown value formatting remains useful for non-Error objects', (t) => {
   t.equal(thrownValueMessage(undefined), 'undefined', 'undefined is explicit');
   t.end();
 });
+
+test('browser run errors retain host stacks and deepest guest locations', async (t) => {
+  const cause = new TypeError("can't convert BigInt to number");
+  cause.jvmGuestLocation = {
+    className: 'ArbitraryMixer',
+    methodName: 'mix',
+    descriptor: '([III)V',
+    pc: 27,
+  };
+  const debug = Object.create(BrowserJVMDebug.prototype);
+  debug.isReady = true;
+  debug.debugController = {
+    executionState: 'stopped',
+    reset() {},
+    jvm: { async run() { throw cause; } },
+  };
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    await debug.run('Example');
+    t.fail('run should reject');
+  } catch (error) {
+    t.equal(error.causeStack, cause.stack,
+      'the original host stack remains available to telemetry');
+    t.deepEqual(error.jvmGuestLocation, cause.jvmGuestLocation,
+      'the deepest guest bytecode location remains machine-readable');
+  } finally {
+    console.error = originalError;
+  }
+  t.end();
+});

--- a/test/jitCompiler.test.js
+++ b/test/jitCompiler.test.js
@@ -395,14 +395,19 @@ test('dense nested array kernels select Wasm without guest-name matching', (t) =
     jit: { warmupThreshold: 0, arrayKernelWasmFirst: true },
   });
   const shape = (name, {
-    arrayAccesses = 24, length = 192, backward = true,
+    primitiveArrayAccesses = 24, referenceArrayAccesses = 0,
+    length = 192, backward = true,
     nonStaticCall = false,
   } = {}) => {
+    const totalArrayAccesses =
+      primitiveArrayAccesses + referenceArrayAccesses;
     const codeItems = Array.from({ length }, (_unused, index) => ({
       labelDef: index === 0 ? 'Lentry:' : `L${index}:`,
-      instruction: index < arrayAccesses
-        ? (index & 1 ? 'aaload' : 'iaload')
-        : index === arrayAccesses && nonStaticCall
+      instruction: index < referenceArrayAccesses
+        ? 'aaload'
+        : index < totalArrayAccesses
+          ? 'iaload'
+          : index === totalArrayAccesses && nonStaticCall
           ? { op: 'invokevirtual',
             arg: ['Method', 'ArbitraryReceiver', ['leaf', '()V']] }
           : index === length - 1 && backward
@@ -419,8 +424,14 @@ test('dense nested array kernels select Wasm without guest-name matching', (t) =
   t.ok(jvm.jit.isArrayKernelWasmFirstMethod(shape('renamedArchiveKernel')),
     'bytecode size, array density, and a backedge select the Wasm policy');
   t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
-    shape('anotherName', { arrayAccesses: 23 })),
+    shape('anotherName', { primitiveArrayAccesses: 23 })),
   'a sparse array body retains the ordinary generated tier');
+  t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
+    shape('referenceHeavyName', {
+      primitiveArrayAccesses: 0,
+      referenceArrayAccesses: 24,
+    })),
+  'reference-array traffic does not satisfy primitive-array density');
   t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
     shape('acyclicName', { backward: false })),
   'an acyclic array helper avoids module compilation overhead');
@@ -957,6 +968,29 @@ test('generated JIT admits call-free post-increment field helpers structurally',
   t.equal(object.fields['ArbitraryCounter.value'], 42,
     'post-increment stores the incremented value');
 
+  const alternateObject = {
+    type: 'ArbitraryCounter',
+    fields: { 'LegacyCounter.value': 9 },
+  };
+  const alternateFrame = new Frame(method);
+  alternateFrame.className = 'ArbitraryCounter';
+  alternateFrame.locals[0] = alternateObject;
+  const alternateStack = new Stack();
+  alternateStack.push(alternateFrame);
+  const alternateResult = generated(
+    alternateFrame,
+    { status: 'runnable', callStack: alternateStack },
+    jvm.jit,
+    false,
+  );
+  t.equal(alternateResult.value, 9,
+    'generated putfield reads an alternate owner-qualified slot');
+  t.equal(alternateObject.fields['LegacyCounter.value'], 10,
+    'generated putfield updates the resolved alternate slot');
+  t.notOk(Object.prototype.hasOwnProperty.call(
+    alternateObject.fields, 'ArbitraryCounter.value'),
+  'generated putfield does not invent the direct slot on unusual objects');
+
   const disabled = new JVM({ jit: {
     warmupThreshold: 0, profileMethods: false, postIncrementHelpers: false,
   } });
@@ -1079,6 +1113,34 @@ test('generated call sites execute proven synchronous JRE leaves directly', (t) 
     'javax/sound/sampled/SourceDataLine', 'javax/sound/sampled/SourceDataLine',
     'drain', '()V'), null,
   'declared async JRE methods retain the canonical scheduler path');
+  t.end();
+});
+
+test('ad-hoc static generated calls carry initialization tokens', (t) => {
+  const jvm = new JVM({ jit: { warmupThreshold: 0 } });
+  jvm.classInitializationState.set('ArbitraryStaticTarget', 'INITIALIZED');
+  const instruction = {
+    op: 'invokestatic',
+    arg: ['Method', 'ArbitraryStaticTarget', ['work', '()V']],
+  };
+  const frame = new Frame({
+    name: 'caller', descriptor: '()V',
+    attributes: [{ type: 'code', code: {
+      codeItems: [], exceptionTable: [], localsSize: '0', stackSize: '0',
+    } }],
+  });
+  let capturedSite = null;
+  const original = jvm.jit.tryInvokeSyncSite;
+  jvm.jit.tryInvokeSyncSite = (site) => {
+    capturedSite = site;
+    return null;
+  };
+  jvm.jit.tryInvokeSync('invokestatic', frame, instruction, {});
+  jvm.jit.tryInvokeSyncSite = original;
+  t.ok(capturedSite.initializationToken,
+    'the ad-hoc static site carries a class-initialization token');
+  t.ok(capturedSite.initializationToken.initialized,
+    'the token exposes the initialized target state');
   t.end();
 });
 

--- a/test/jitCompiler.test.js
+++ b/test/jitCompiler.test.js
@@ -10,15 +10,36 @@ const { JVM } = require('../src/core/jvm');
 const { _test: wasmJitTest } = require('../src/jit/WasmJit');
 const {
   supportsWasmTryTable,
+  mathIntrinsicFunction,
 } = require('../src/jit/wasmShared');
 const { _test: structuredRendererTest } = require('../src/jit/JvmSsaBlockRenderer');
 const HandwrittenFusedGradient = require('../src/jit/HandwrittenFusedGradient');
+const HandwrittenAffineSpriteRaster =
+  require('../src/jit/HandwrittenAffineSpriteRaster');
 const invokeHandlers = require('../src/instructions/invoke');
+const objectHandlers = require('../src/instructions/object');
 const Frame = require('../src/core/frame');
 const Stack = require('../src/core/stack');
 const awt = require('../src/platform/awt');
 
 const WASM_TRY_TABLE_SUPPORTED = supportsWasmTryTable();
+
+test('Wasm Math imports preserve exact Java long semantics', (t) => {
+  const abs = mathIntrinsicFunction('abs', '(J)J');
+  const max = mathIntrinsicFunction('max', '(JJ)J');
+  const min = mathIntrinsicFunction('min', '(JJ)J');
+  const minimumLong = -0x8000000000000000n;
+  t.equal(abs(-37n), 37n, 'long abs never crosses through Number');
+  t.equal(abs(minimumLong), minimumLong,
+    'Long.MIN_VALUE abs preserves Java overflow semantics');
+  t.equal(max(0x7fffffffffffffffn, -1n), 0x7fffffffffffffffn,
+    'long max remains exact above Number safe-integer range');
+  t.equal(min(-0x8000000000000000n, 1n), minimumLong,
+    'long min remains exact below Number safe-integer range');
+  t.equal(mathIntrinsicFunction('sqrt', '(J)J'), null,
+    'nonexistent long Math overloads stay outside the intrinsic tier');
+  t.end();
+});
 
 test('handwritten region fingerprints ignore guest class and method names', (t) => {
   const shape = (owner, dependency, methodName, fieldName, constant = 7) => ({
@@ -42,6 +63,207 @@ test('handwritten region fingerprints ignore guest class and method names', (t) 
   t.equal(renamed, original,
     'consistent owner, member, and descriptor renaming leaves the shape unchanged');
   t.notEqual(altered, original, 'an altered bytecode constant changes the verified shape');
+  t.end();
+});
+
+test('affine sprite raster preserves Java sampling and rejects before writes', (t) => {
+  const { roundedFloorDivide, runRaster } = HandwrittenAffineSpriteRaster._test;
+  for (let numerator = -7; numerator <= 7; numerator += 1) {
+    t.equal(roundedFloorDivide(3, numerator), Math.floor(numerator / 3),
+      `verified division helper preserves floor semantics for ${numerator}`);
+  }
+
+  const base = {
+    width: 2,
+    height: 2,
+    source: Int32Array.from([10, 20, 30, 40]),
+    mask: null,
+    destination: new Int32Array(4),
+    clipOuterStart: 0,
+    clipOuterEnd: 2,
+    clipInnerStart: 0,
+    clipInnerEnd: 2,
+    surfaceStride: 2,
+  };
+  const args = [0, 2, 0, 0, 2, 2, 0, 0, 0, -1];
+  t.ok(runRaster(base, args), 'ordinary affine raster input is accepted');
+  t.deepEqual(Array.from(base.destination), [10, 20, 30, 40],
+    'column scan writes the same moving source coordinates');
+
+  const masked = {
+    ...base,
+    mask: Int8Array.from([1, 0, 1, 1]),
+    destination: new Int32Array(4),
+  };
+  t.ok(runRaster(masked, args), 'masked affine raster input is accepted');
+  t.deepEqual(Array.from(masked.destination), [10, 0, 30, 40],
+    'mask coordinates independently suppress source pixels');
+
+  const invalidDestination = Int32Array.from([101, 102, 103]);
+  const invalid = {
+    ...base,
+    destination: invalidDestination,
+  };
+  t.notOk(runRaster(invalid, args), 'short destination rejects the fast path');
+  t.deepEqual(Array.from(invalidDestination), [101, 102, 103],
+    'bounds rejection happens before the first destination write');
+
+  const negativeSourceX = {
+    ...base,
+    destination: Int32Array.from([201, 202, 203, 204]),
+  };
+  t.notOk(runRaster(negativeSourceX,
+    [0, 2, 0, 0, 2, 2, 0, 0, -4, -1]),
+  'unsupported negative remainder rejects the fast path');
+  t.deepEqual(Array.from(negativeSourceX.destination), [201, 202, 203, 204],
+    'source-coordinate rejection is also side-effect free');
+  t.end();
+});
+
+function referenceAffineSpriteRaster(data, inputArgs) {
+  const divide = (numerator, denominator) => (numerator / denominator) | 0;
+  const floorDivide = (denominator, numerator) => {
+    const sign = numerator >>> 31;
+    return (divide((numerator + sign) | 0, denominator) - sign) | 0;
+  };
+  const args = inputArgs.map(value => value | 0);
+  const [outerStart, outerEnd, leftStart, leftEnd, rightStart, rightEnd,
+    dim, blend, sourceOffset, maskOverride] = args;
+  const outerSpan = (outerEnd - outerStart) | 0;
+  let firstOuter = outerStart;
+  if (firstOuter < data.clipOuterStart) firstOuter = data.clipOuterStart;
+  let lastOuter = outerEnd;
+  if (lastOuter > data.clipOuterEnd) lastOuter = data.clipOuterEnd;
+  for (let outer = firstOuter; outer < lastOuter; outer += 1) {
+    let maskX = divide((
+      Math.imul(data.width, (outer - outerStart) | 0) +
+      (outerSpan >> 1)
+    ) | 0, outerSpan);
+    if (maskX >= data.width) maskX = (data.width - 1) | 0;
+    const sourceX = ((maskX + sourceOffset) | 0) % data.width;
+    if (maskOverride >= 0) maskX = maskOverride;
+    const leftDelta = (leftEnd - leftStart) | 0;
+    const rightDelta = (rightEnd - rightStart) | 0;
+    const left = (
+      Math.imul(leftStart, outerSpan) +
+      Math.imul(leftDelta, (outer - outerStart) | 0) +
+      (leftDelta >> 1)
+    ) | 0;
+    const right = (
+      Math.imul(rightStart, outerSpan) +
+      Math.imul(rightDelta, (outer - outerStart) | 0) +
+      (rightDelta >> 1)
+    ) | 0;
+    const innerSpan = (right - left) | 0;
+    let firstInner = floorDivide(
+      outerSpan, (left + (outerSpan >> 1)) | 0);
+    if (firstInner < data.clipInnerStart) firstInner = data.clipInnerStart;
+    let lastInner = floorDivide(
+      outerSpan, (right + (outerSpan >> 1)) | 0);
+    if (lastInner > data.clipInnerEnd) lastInner = data.clipInnerEnd;
+    if (lastInner <= firstInner) continue;
+    let sourceFixed = (
+      Math.imul(data.height,
+        (Math.imul(firstInner, outerSpan) - left) | 0) +
+      (innerSpan >> 1)
+    ) | 0;
+    let sourceFixedLast = (
+      Math.imul(data.height,
+        (Math.imul((lastInner - 1) | 0, outerSpan) - left) | 0) +
+      (innerSpan >> 1)
+    ) | 0;
+    if (sourceFixed <= -innerSpan) sourceFixed = (-innerSpan + 1) | 0;
+    const sourceLimit = Math.imul(data.height, innerSpan);
+    if (sourceFixed >= sourceLimit) sourceFixed = (sourceLimit - 1) | 0;
+    if (sourceFixedLast >= sourceLimit) {
+      sourceFixedLast = (sourceLimit - 1) | 0;
+    }
+    let sourceStep = 0;
+    if (sourceFixedLast > sourceFixed) {
+      sourceStep = divide(
+        (sourceFixedLast - sourceFixed) | 0,
+        (lastInner - firstInner - 1) | 0);
+    }
+    let destinationIndex =
+      (Math.imul(firstInner, data.surfaceStride) + outer) | 0;
+    for (let inner = firstInner; inner < lastInner; inner += 1) {
+      const sourceY = divide(sourceFixed, innerSpan);
+      const sourceRow = Math.imul(sourceY, data.width);
+      let color = data.source[(sourceRow + sourceX) | 0] | 0;
+      if (color !== 0 &&
+          (!data.mask || (data.mask[(sourceRow + maskX) | 0] | 0) !== 0)) {
+        if (dim) color = (color >> 1) & 8355711;
+        if (blend) {
+          color = (
+            color + ((data.destination[destinationIndex] >> 1) & 8355711)
+          ) | 0;
+        }
+        data.destination[destinationIndex] = color;
+      }
+      destinationIndex = (destinationIndex + data.surfaceStride) | 0;
+      sourceFixed = (sourceFixed + sourceStep) | 0;
+    }
+  }
+}
+
+test('affine sprite raster differentially matches 200 moving invocations', (t) => {
+  const { runRaster } = HandwrittenAffineSpriteRaster._test;
+  let randomState = 0x51f15e;
+  const random = () => {
+    randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0;
+    return randomState;
+  };
+  const failures = [];
+  for (let invocation = 0; invocation < 200; invocation += 1) {
+    const width = 1 + random() % 6;
+    const height = 1 + random() % 6;
+    const source = Int32Array.from({ length: width * height }, () =>
+      random() % 5 === 0 ? 0 : random() & 0xffffff);
+    const mask = invocation % 3 === 0
+      ? Int8Array.from({ length: width * height }, () => random() & 1)
+      : null;
+    const initial = Int32Array.from({ length: 16 * 16 }, () =>
+      random() & 0xffffff);
+    const actual = initial.slice();
+    const expected = initial.slice();
+    const outerStart = random() % 4;
+    const outerSpan = 2 + random() % 8;
+    const leftStart = random() % 4;
+    const leftEnd = random() % 4;
+    const drawWidth = 1 + random() % 7;
+    const args = [
+      outerStart,
+      outerStart + outerSpan,
+      leftStart,
+      leftEnd,
+      leftStart + drawWidth,
+      leftEnd + drawWidth,
+      random() & 1,
+      random() & 1,
+      random() % width,
+      invocation % 4 === 0 ? random() % width : -1,
+    ];
+    const shared = {
+      width,
+      height,
+      source,
+      mask,
+      clipOuterStart: random() % 4,
+      clipOuterEnd: 12 + random() % 5,
+      clipInnerStart: random() % 4,
+      clipInnerEnd: 12 + random() % 5,
+      surfaceStride: 16,
+    };
+    referenceAffineSpriteRaster({ ...shared, destination: expected }, args);
+    const accepted = runRaster({ ...shared, destination: actual }, args);
+    if (!accepted ||
+        actual.some((value, index) => value !== expected[index])) {
+      failures.push({ invocation, accepted, args, actual, expected });
+      break;
+    }
+  }
+  t.equal(failures.length, 0,
+    'all moving, clipped, masked, dimmed, and blended surfaces are bit exact');
   t.end();
 });
 
@@ -165,6 +387,48 @@ test('long-arithmetic loop policy selects Wasm by opcode shape, not method ident
     'constructors retain their observable initialization policy');
   t.equal(jvm.jit.longArithmeticWasmFirstMethodCount, 1,
     'the runtime counter records a structurally selected method once');
+  t.end();
+});
+
+test('dense nested array kernels select Wasm without guest-name matching', (t) => {
+  const jvm = new JVM({
+    jit: { warmupThreshold: 0, arrayKernelWasmFirst: true },
+  });
+  const shape = (name, {
+    arrayAccesses = 24, length = 192, backward = true,
+    nonStaticCall = false,
+  } = {}) => {
+    const codeItems = Array.from({ length }, (_unused, index) => ({
+      labelDef: index === 0 ? 'Lentry:' : `L${index}:`,
+      instruction: index < arrayAccesses
+        ? (index & 1 ? 'aaload' : 'iaload')
+        : index === arrayAccesses && nonStaticCall
+          ? { op: 'invokevirtual',
+            arg: ['Method', 'ArbitraryReceiver', ['leaf', '()V']] }
+          : index === length - 1 && backward
+            ? { op: 'goto', arg: 'Lentry' }
+            : 'nop',
+    }));
+    return {
+      name,
+      descriptor: '([[I[I)V',
+      flags: ['private', 'static'],
+      attributes: [{ type: 'code', code: { codeItems, exceptionTable: [] } }],
+    };
+  };
+  t.ok(jvm.jit.isArrayKernelWasmFirstMethod(shape('renamedArchiveKernel')),
+    'bytecode size, array density, and a backedge select the Wasm policy');
+  t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
+    shape('anotherName', { arrayAccesses: 23 })),
+  'a sparse array body retains the ordinary generated tier');
+  t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
+    shape('acyclicName', { backward: false })),
+  'an acyclic array helper avoids module compilation overhead');
+  t.notOk(jvm.jit.isArrayKernelWasmFirstMethod(
+    shape('dynamicName', { nonStaticCall: true })),
+  'a dynamic call boundary retains the single-tier JavaScript policy');
+  t.equal(jvm.jit.arrayKernelWasmFirstMethodCount, 1,
+    'the structural selection is counted once');
   t.end();
 });
 
@@ -717,6 +981,66 @@ test('initialized static fields stay on the synchronous generated fast path', (t
   t.equal(changed, true, 'warm putstatic completes synchronously');
   t.equal(jvm.classes.FastStatics.staticFields.get('value:I'), 42,
     'warm putstatic updates the field');
+  t.end();
+});
+
+test('resolved class initialization uses stable hot-site tokens', (t) => {
+  const jvm = new JVM({ jit: { warmupThreshold: 0 } });
+  jvm.classes.ArbitraryStaticOwner = {
+    ast: { classes: [{ superClassName: null, items: [] }] },
+    staticFields: new Map([['value:I', 37]]),
+  };
+  jvm.classInitializationState.set('ArbitraryStaticOwner', 'INITIALIZED');
+  const site = jvm.jit.registerFieldSite(
+    ['Field', 'ArbitraryStaticOwner', ['value', 'I']]);
+  let stateLookups = 0;
+  const originalGet = jvm.classInitializationState.get;
+  jvm.classInitializationState.get = function countedGet(...args) {
+    stateLookups += 1;
+    return originalGet.apply(this, args);
+  };
+  for (let iteration = 0; iteration < 100; iteration += 1) {
+    t.equal(jvm.jit.getStaticSyncAt(site), 37,
+      'resolved static access retains the current value');
+  }
+  t.equal(stateLookups, 0,
+    'warm static accesses do not repeat class-state Map lookups');
+  jvm.classInitializationState.set('ArbitraryStaticOwner', 'UNINITIALIZED');
+  t.equal(jvm.jit.getStaticSyncAt(site), jvm.jit.staticDeopt(),
+    'an observed lifecycle change invalidates the stable token');
+  jvm.classInitializationState.set('ArbitraryStaticOwner', 'INITIALIZED');
+  t.equal(jvm.jit.getStaticSyncAt(site), 37,
+    'the same token resumes after initialization is published');
+  t.end();
+});
+
+test('interpreted warm getstatic sites reuse class-initialization tokens', (t) => {
+  const jvm = new JVM({ jit: { enabled: false } });
+  jvm.classes.ArbitraryStaticOwner = {
+    ast: { classes: [{ superClassName: null, items: [] }] },
+    staticFields: new Map([['value:I', 19]]),
+  };
+  jvm.classInitializationState.set('ArbitraryStaticOwner', 'INITIALIZED');
+  const instruction = { op: 'getstatic',
+    arg: ['Field', 'ArbitraryStaticOwner', ['value', 'I']] };
+  const frame = { stack: new Stack() };
+  const thread = { id: 7 };
+  let stateLookups = 0;
+  const originalGet = jvm.classInitializationState.get;
+  jvm.classInitializationState.get = function countedGet(...args) {
+    stateLookups += 1;
+    return originalGet.apply(this, args);
+  };
+  for (let iteration = 0; iteration < 100; iteration += 1) {
+    objectHandlers.getstaticSync(frame, instruction, jvm, thread);
+    t.equal(frame.stack.pop(), 19, 'warm interpreted static read stays exact');
+  }
+  t.equal(stateLookups, 1,
+    'the interpreted site resolves initialization state only once');
+  jvm.classInitializationState.set('ArbitraryStaticOwner', 'ERRONEOUS');
+  t.equal(objectHandlers.getstaticSync(frame, instruction, jvm, thread),
+    objectHandlers.SYNC_STATIC_FALLBACK,
+  'the stable token observes lifecycle changes without another map lookup');
   t.end();
 });
 
@@ -3595,6 +3919,11 @@ public class ScalarFeatureHarness {
     'structured SSA preserves array, field, remainder, and static-call effects');
   t.ok(structured.generated?.jvmStructuredSsa,
     'array/field/call loop selects structured SSA without method-name recognition');
+  t.ok(structured.generated?.jvmStructuredFieldReadCacheCount >= 2,
+    'call-bearing loops cache non-volatile fields between effect boundaries');
+  t.ok(structured.generated?.jvmStructuredSource.includes(
+    'ssaFieldCache0Valid = false'),
+  'calls invalidate cached field values before another guest effect');
   t.ok(structured.repeatedGenerated?.jvmStructuredFieldReadCacheCount >= 2,
     'call-free structured loops cache non-volatile fields by receiver identity');
   t.equal(structured.volatileGenerated?.jvmStructuredFieldReadCacheCount, 0,

--- a/test/jreEdgeCases.test.js
+++ b/test/jreEdgeCases.test.js
@@ -38,6 +38,27 @@ const {
   getFileProvider,
   setFileProvider,
 } = require('../src/core/classLoader');
+const {
+  completeReflectiveCall,
+} = require('../src/instructions/control');
+
+const JAVAC_AVAILABLE = (() => {
+  try {
+    execFileSync('javac', ['-version'], { stdio: 'ignore' });
+    return true;
+  } catch (_) {
+    return false;
+  }
+})();
+
+function compileHarness(directory, filename, source) {
+  const sourcePath = path.join(directory, filename);
+  fs.writeFileSync(sourcePath, source);
+  execFileSync('javac', [
+    '-source', '8', '-target', '8', '-d', directory, sourcePath,
+  ], { stdio: 'ignore' });
+  return sourcePath;
+}
 
 function jvmStub() {
   return {
@@ -104,22 +125,37 @@ test('Class reflective method lookup preserves array parameter descriptors', asy
     'declared lookup encodes int[] as [I rather than L[I;');
   t.equal(inherited._methodData, method,
     'public lookup uses the same array descriptor encoding');
+  let nullParameterError = null;
+  try {
+    Class.methods[
+      'getDeclaredMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;'
+    ]({}, owner, ['mix', [intClass, null]]);
+  } catch (error) {
+    nullParameterError = error;
+  }
+  t.equal(nullParameterError && nullParameterError.type,
+    'java/lang/IllegalArgumentException',
+  'a null parameter type cannot silently shorten a method descriptor');
   t.end();
 });
 
 test('reflective constructors run their body through nested calls', async (t) => {
+  if (!JAVAC_AVAILABLE) {
+    t.skip('javac is unavailable');
+    t.end();
+    return;
+  }
   const directory = fs.mkdtempSync(path.join(os.tmpdir(),
     'jvm-reflective-constructor-'));
   t.teardown(() => fs.rmSync(directory, { recursive: true, force: true }));
-  const source = path.join(directory, 'ReflectiveConstructorHarness.java');
-  fs.writeFileSync(source, `
+  compileHarness(directory, 'ReflectiveConstructorHarness.java', `
 public final class ReflectiveConstructorHarness {
   static int result;
   private static final class Value {
     int value;
-    private Value(int input) {
+    private Value(long wide, double fraction, boolean enabled, int input) {
       super();
-      value = adjust(input);
+      value = adjust((int) wide + (int) fraction + (enabled ? input : 0));
     }
     private int adjust(int input) {
       return input * 3;
@@ -127,27 +163,33 @@ public final class ReflectiveConstructorHarness {
   }
   public static void main(String[] args) throws Exception {
     java.lang.reflect.Constructor<Value> constructor =
-      Value.class.getDeclaredConstructor(int.class);
+      Value.class.getDeclaredConstructor(
+        long.class, double.class, boolean.class, int.class);
     constructor.setAccessible(true);
-    result = constructor.newInstance(Integer.valueOf(7)).value;
+    result = constructor.newInstance(
+      Long.valueOf(4L), Double.valueOf(2.0), Boolean.TRUE,
+      Integer.valueOf(7)).value;
   }
 }
 `);
-  execFileSync('javac', ['-source', '8', '-target', '8', '-d', directory,
-    source], { stdio: 'ignore' });
   const jvm = new JVM({ classpath: directory, jit: { enabled: false } });
   await jvm.run('ReflectiveConstructorHarness');
   t.equal(jvm.classes.ReflectiveConstructorHarness.staticFields.get('result:I'),
-    21, 'the requested constructor, super call, and nested helper all finish');
+    39,
+  'wide and boxed constructor arguments reach the requested nested body');
   t.end();
 });
 
 test('generated void methods complete reflective calls with a null result', async (t) => {
+  if (!JAVAC_AVAILABLE) {
+    t.skip('javac is unavailable');
+    t.end();
+    return;
+  }
   const directory = fs.mkdtempSync(path.join(os.tmpdir(),
     'jvm-reflective-generated-void-'));
   t.teardown(() => fs.rmSync(directory, { recursive: true, force: true }));
-  const source = path.join(directory, 'ReflectiveGeneratedVoidHarness.java');
-  fs.writeFileSync(source, `
+  compileHarness(directory, 'ReflectiveGeneratedVoidHarness.java', `
 public final class ReflectiveGeneratedVoidHarness {
   static int result;
   static int calls;
@@ -172,8 +214,6 @@ public final class ReflectiveGeneratedVoidHarness {
   }
 }
 `);
-  execFileSync('javac', ['-source', '8', '-target', '8', '-d', directory,
-    source], { stdio: 'ignore' });
   const jvm = new JVM({ classpath: directory, jit: {
     warmupThreshold: 0,
     preferWholeMethodJs: true,
@@ -199,6 +239,25 @@ public final class ReflectiveGeneratedVoidHarness {
     120,
     'the generated target returns null to Method.invoke before caller pop/branch',
   );
+  t.end();
+});
+
+test('reflective completion clears state before invoking its resolver', (t) => {
+  const frame = {};
+  const thread = {
+    isAwaitingReflectiveCall: true,
+    reflectiveCallFrame: frame,
+    reflectiveCallResolver() {
+      throw new Error('resolver failed');
+    },
+  };
+  t.throws(() => completeReflectiveCall(thread, null), /resolver failed/);
+  t.equal(thread.isAwaitingReflectiveCall, false,
+    'a throwing resolver cannot leave reflective mode active');
+  t.equal(thread.reflectiveCallResolver, null,
+    'a throwing resolver is detached before it runs');
+  t.equal(thread.reflectiveCallFrame, null,
+    'a throwing resolver cannot capture the next returning frame');
   t.end();
 });
 
@@ -537,6 +596,27 @@ test('disabled SourceDataLine applies backpressure', (t) => {
 
   if (previous === undefined) delete process.env.JVM_DISABLE_AUDIO;
   else process.env.JVM_DISABLE_AUDIO = previous;
+  t.end();
+});
+
+test('SourceDataLine audio priority uses the scheduler clock', (t) => {
+  const output = {
+    write() {},
+    queuedSeconds() { return 0; },
+  };
+  const line = { audioOutput: output, isOpen: true };
+  const thread = { id: 7, status: 'runnable' };
+  const jvm = {
+    clock: { millis() { return 1250; } },
+    _audioPriority: null,
+  };
+  SourceDataLine.methods['write([BII)I'](
+    jvm, line, [[0, 0], 0, 2], thread,
+  );
+  t.equal(jvm._audioPriority.until, 1300,
+    'the priority deadline is derived from the scheduler clock');
+  t.equal(jvm._audioPriority.thread, thread,
+    'the producing guest thread receives temporary priority');
   t.end();
 });
 

--- a/test/jreEdgeCases.test.js
+++ b/test/jreEdgeCases.test.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const test = require('tape');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { execFileSync } = require('child_process');
+const { JVM } = require('../src/core/jvm');
 
 const File = require('../src/jre/java/io/File');
 const FileInputStream = require('../src/jre/java/io/FileInputStream');
@@ -56,6 +60,145 @@ test('Class.newInstance reports InstantiationException for primitive classes', a
     error = caught;
   }
   t.equal(error && error.type, 'java/lang/InstantiationException');
+  t.end();
+});
+
+test('Class reflective method lookup preserves array parameter descriptors', async (t) => {
+  const method = {
+    name: 'mix',
+    descriptor: '([II)V',
+    flags: ['public'],
+  };
+  const owner = {
+    type: 'java/lang/Class',
+    _classData: {
+      ast: {
+        classes: [{
+          className: 'AudioScheduler',
+          superClassName: null,
+          items: [{ type: 'method', method }],
+        }],
+      },
+    },
+  };
+  const intArray = {
+    type: 'java/lang/Class',
+    className: '[I',
+    _classData: {
+      isArray: true,
+      className: '[I',
+      componentType: 'I',
+    },
+  };
+  const intClass = { isPrimitive: true, name: 'int' };
+  const parameters = [intArray, intClass];
+
+  const declared = Class.methods[
+    'getDeclaredMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;'
+  ]({}, owner, ['mix', parameters]);
+  const inherited = await Class.methods[
+    'getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;'
+  ]({}, owner, ['mix', parameters]);
+
+  t.equal(declared._methodData, method,
+    'declared lookup encodes int[] as [I rather than L[I;');
+  t.equal(inherited._methodData, method,
+    'public lookup uses the same array descriptor encoding');
+  t.end();
+});
+
+test('reflective constructors run their body through nested calls', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(),
+    'jvm-reflective-constructor-'));
+  t.teardown(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const source = path.join(directory, 'ReflectiveConstructorHarness.java');
+  fs.writeFileSync(source, `
+public final class ReflectiveConstructorHarness {
+  static int result;
+  private static final class Value {
+    int value;
+    private Value(int input) {
+      super();
+      value = adjust(input);
+    }
+    private int adjust(int input) {
+      return input * 3;
+    }
+  }
+  public static void main(String[] args) throws Exception {
+    java.lang.reflect.Constructor<Value> constructor =
+      Value.class.getDeclaredConstructor(int.class);
+    constructor.setAccessible(true);
+    result = constructor.newInstance(Integer.valueOf(7)).value;
+  }
+}
+`);
+  execFileSync('javac', ['-source', '8', '-target', '8', '-d', directory,
+    source], { stdio: 'ignore' });
+  const jvm = new JVM({ classpath: directory, jit: { enabled: false } });
+  await jvm.run('ReflectiveConstructorHarness');
+  t.equal(jvm.classes.ReflectiveConstructorHarness.staticFields.get('result:I'),
+    21, 'the requested constructor, super call, and nested helper all finish');
+  t.end();
+});
+
+test('generated void methods complete reflective calls with a null result', async (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(),
+    'jvm-reflective-generated-void-'));
+  t.teardown(() => fs.rmSync(directory, { recursive: true, force: true }));
+  const source = path.join(directory, 'ReflectiveGeneratedVoidHarness.java');
+  fs.writeFileSync(source, `
+public final class ReflectiveGeneratedVoidHarness {
+  static int result;
+  static int calls;
+  static int valueAfter;
+  static int nullResult;
+  private void fill(int[] values, int increment) {
+    calls++;
+    values[2] += increment;
+  }
+  public static void main(String[] args) throws Exception {
+    ReflectiveGeneratedVoidHarness owner =
+      new ReflectiveGeneratedVoidHarness();
+    java.lang.reflect.Method method =
+      ReflectiveGeneratedVoidHarness.class.getDeclaredMethod(
+        "fill", int[].class, int.class);
+    method.setAccessible(true);
+    int[] values = { 1, 2, 3 };
+    Object returned = method.invoke(owner, values, Integer.valueOf(7));
+    valueAfter = values[2];
+    nullResult = returned == null ? 1 : 0;
+    result = calls * 100 + nullResult * 10 + valueAfter;
+  }
+}
+`);
+  execFileSync('javac', ['-source', '8', '-target', '8', '-d', directory,
+    source], { stdio: 'ignore' });
+  const jvm = new JVM({ classpath: directory, jit: {
+    warmupThreshold: 0,
+    preferWholeMethodJs: true,
+  } });
+  await jvm.run('ReflectiveGeneratedVoidHarness');
+  t.equal(
+    jvm.classes.ReflectiveGeneratedVoidHarness.staticFields.get('calls:I'),
+    1,
+    'the reflected target runs once',
+  );
+  t.equal(
+    jvm.classes.ReflectiveGeneratedVoidHarness.staticFields.get('nullResult:I'),
+    1,
+    'Method.invoke observes the generated void return as null',
+  );
+  t.equal(
+    jvm.classes.ReflectiveGeneratedVoidHarness.staticFields.get('valueAfter:I'),
+    10,
+    'the reflected target receives the original array and boxed integer',
+  );
+  t.equal(
+    jvm.classes.ReflectiveGeneratedVoidHarness.staticFields.get('result:I'),
+    120,
+    'the generated target returns null to Method.invoke before caller pop/branch',
+  );
   t.end();
 });
 

--- a/test/structuredWasm.test.js
+++ b/test/structuredWasm.test.js
@@ -888,3 +888,45 @@ public class NestedEhCallee {
   t.ok(riskySt && riskySt.nestedCalls > 0, 'EH callee ran nested');
   t.end();
 });
+
+test('structured SSA resumes after a nested callee catches with wasm disabled', async (t) => {
+  const { jvm, thread } = await makeHarness(t, 'NestedEhJsFallback', `
+public class NestedEhJsFallback {
+  int[] tab = null;
+  int risky(int i) {
+    try {
+      return tab[i & 7];
+    } catch (NullPointerException e) {
+      return 5;
+    }
+  }
+  public int drive(int[] out, int n) {
+    int sum = 0;
+    for (int i = 0; i < n; i++) sum += risky(i) + (i & 1);
+    out[0] = sum;
+    return sum;
+  }
+}
+`, { JVM_WASM_JIT: '0', JVM_WASM_STRUCTURED: '0' });
+  const n = 64;
+  let expected = 0;
+  for (let i = 0; i < n; i++) expected = (expected + 5 + (i & 1)) | 0;
+  const out = [0];
+  out.type = '[I';
+  const recv = {
+    type: 'NestedEhJsFallback',
+    fields: { 'NestedEhJsFallback.tab': null },
+    hashCode: 17,
+  };
+  await invoke(
+    jvm, thread, 'NestedEhJsFallback', 'drive', '([II)I', [recv, out, n],
+  );
+  t.equal(out[0], expected, 'callee return resumes the caller after the invoke');
+  const drive = await jvm.findMethodInHierarchy(
+    'NestedEhJsFallback', 'drive', '([II)I',
+  );
+  const generated = jvm.jit.getGeneratedFunction(drive);
+  t.ok(generated && generated.jvmStructuredSsa,
+    'caller used the structured SSA tier');
+  t.end();
+});

--- a/test/webAudio.test.js
+++ b/test/webAudio.test.js
@@ -129,7 +129,9 @@ test("WebAudio unlocks before a delayed SourceDataLine open", async (t) => {
     coalesceDelayMs: 0,
   });
   const buffersBefore = closedDiagnostics.scheduledBuffers;
-  coalesced.write(new Uint8Array([0, 0, 1, 0]));
+  const reusablePcm = new Uint8Array([0, 0, 1, 0]);
+  coalesced.write(reusablePcm);
+  reusablePcm.fill(127);
   t.equal(audioPlatform.getWebAudioDiagnostics().scheduledBuffers, buffersBefore,
     "a partial continuous region remains staged");
   t.equal(coalesced.available(), 4092,
@@ -219,6 +221,7 @@ test("WebAudio starts short effect lines after their first region", async (t) =>
   const listeners = new Map();
   let factory = null;
   let workletOptions = null;
+  let workletNode = null;
   const posted = [];
   class FakeAudioContext {
     constructor() {
@@ -233,6 +236,7 @@ test("WebAudio starts short effect lines after their first region", async (t) =>
   class FakeAudioWorkletNode {
     constructor(_context, _name, options) {
       workletOptions = options;
+      workletNode = this;
       this.port = {
         onmessage: null,
         postMessage(message) { posted.push(message); },
@@ -288,6 +292,22 @@ test("WebAudio starts short effect lines after their first region", async (t) =>
   t.equal(audioPlatform.getWebAudioDiagnostics().outputFormats[0]
     .workletStartFrames, 512,
   "telemetry exposes the per-line startup threshold");
+  let drained = false;
+  output.once("drain", () => { drained = true; });
+  await new Promise(resolve => setImmediate(resolve));
+  t.equal(drained, false,
+    "worklet drain waits while published PCM remains queued");
+  workletNode.port.onmessage({ data: { type: "queue", frames: 0 } });
+  await new Promise(resolve => setTimeout(resolve, 0));
+  t.equal(drained, true,
+    "worklet drain completes after the processor reports an empty queue");
+  output.write(new Uint8Array(512 * 2 * 2));
+  output.flush();
+  const flush = posted.find(message => message.type === "flush");
+  t.deepEqual(flush, { type: "flush", generation: 1 },
+    "flush advances the worklet generation");
+  t.equal(output.queuedSeconds(), 0,
+    "flush clears the main-thread worklet queue accounting");
   output.end();
   t.end();
 });

--- a/test/webAudio.test.js
+++ b/test/webAudio.test.js
@@ -12,6 +12,7 @@ test("WebAudio unlocks before a delayed SourceDataLine open", async (t) => {
   let resumeCalls = 0;
   let stopCalls = 0;
   let lastContext = null;
+  const createdBuffers = [];
   class FakeAudioContext {
     constructor() {
       contextCreations += 1;
@@ -30,10 +31,14 @@ test("WebAudio unlocks before a delayed SourceDataLine open", async (t) => {
 
     createBuffer(channels, frames, sampleRate) {
       const data = Array.from({ length: channels }, () => new Float32Array(frames));
-      return {
+      const buffer = {
+        channels,
+        data,
         duration: frames / sampleRate,
         getChannelData(channel) { return data[channel]; },
       };
+      createdBuffers.push(buffer);
+      return buffer;
     }
 
     createBufferSource() {
@@ -80,6 +85,8 @@ test("WebAudio unlocks before a delayed SourceDataLine open", async (t) => {
     sampleRate: 22050,
     signed: true,
     bigEndian: false,
+    coalesceFrames: 1,
+    coalesceDelayMs: 0,
   });
   output.write(new Uint8Array([0, 0, 255, 127]));
   const diagnostics = audioPlatform.getWebAudioDiagnostics();
@@ -111,5 +118,176 @@ test("WebAudio unlocks before a delayed SourceDataLine open", async (t) => {
   t.equal(closedDiagnostics.activeOutputs, 0,
     "closed outputs no longer contribute to queue diagnostics");
   t.equal(closedDiagnostics.closedOutputs, 1, "closed outputs are counted");
+
+  const coalesced = factory({
+    channels: 1,
+    bitDepth: 16,
+    sampleRate: 22050,
+    signed: true,
+    bigEndian: false,
+    coalesceFrames: 4,
+    coalesceDelayMs: 0,
+  });
+  const buffersBefore = closedDiagnostics.scheduledBuffers;
+  coalesced.write(new Uint8Array([0, 0, 1, 0]));
+  t.equal(audioPlatform.getWebAudioDiagnostics().scheduledBuffers, buffersBefore,
+    "a partial continuous region remains staged");
+  t.equal(coalesced.available(), 4092,
+    "staged PCM consumes SourceDataLine capacity before scheduling");
+  coalesced.write(new Uint8Array([2, 0, 3, 0]));
+  const coalescedDiagnostics = audioPlatform.getWebAudioDiagnostics();
+  t.equal(coalescedDiagnostics.scheduledBuffers, buffersBefore + 1,
+    "adjacent guest writes become one WebAudio source");
+  t.equal(coalescedDiagnostics.coalescedWrites, 1,
+    "diagnostics report the removed resampler boundary");
+  t.deepEqual(coalescedDiagnostics.outputFormats[0], {
+    sampleRate: 22050,
+    channels: 1,
+    bitDepth: 16,
+    signed: true,
+    bigEndian: false,
+    bufferSize: 4096,
+    playbackChannels: 1,
+    forceMono: false,
+    backend: "buffer-sources",
+    coalesceFrames: 4,
+    coalesceDelayMs: 0,
+    workletStartFrames: 4,
+    guestWrites: 2,
+    scheduledBuffers: 1,
+    stagedFrames: 0,
+    queuedSeconds: 0,
+    underruns: 0,
+    underrunSeconds: 0,
+    decodedFrames: 4,
+    pcmChecksum: 28688826,
+    channelPcmChecksums: [28688826],
+    firstNonSilentFrame: 1,
+    contentFrames: 3,
+    contentPcmChecksum: 28688826,
+    channelContentPcmChecksums: [28688826],
+    channelAverageAmplitude: [0.000046],
+    channelAverageDifference: [0.000023],
+  }, "diagnostics expose the exact browser PCM contract");
+  coalesced.end();
+
+  const downmixed = factory({
+    channels: 2,
+    bitDepth: 16,
+    sampleRate: 22050,
+    signed: true,
+    bigEndian: false,
+    coalesceFrames: 1,
+    coalesceDelayMs: 0,
+    forceMono: true,
+  });
+  downmixed.write(new Uint8Array([255, 127, 0, 128]));
+  const downmixDiagnostics = audioPlatform.getWebAudioDiagnostics();
+  const downmixFormat = downmixDiagnostics.outputFormats[0];
+  t.equal(downmixFormat.channels, 2,
+    "downmix diagnostics retain the guest stereo input contract");
+  t.equal(downmixFormat.playbackChannels, 1,
+    "the explicit diagnostic mode publishes mono playback");
+  t.equal(createdBuffers[createdBuffers.length - 1].channels, 1,
+    "stereo PCM is scheduled in a mono WebAudio buffer");
+  t.ok(Math.abs(createdBuffers[createdBuffers.length - 1].data[0][0]) <
+    1 / 32768,
+  "mono playback averages the left and right samples");
+  downmixed.end();
+
+  const timed = factory({
+    channels: 1,
+    bitDepth: 16,
+    sampleRate: 22050,
+    signed: true,
+    bigEndian: false,
+    coalesceFrames: 4,
+    coalesceDelayMs: 1,
+  });
+  const timedBuffersBefore =
+    audioPlatform.getWebAudioDiagnostics().scheduledBuffers;
+  timed.write(new Uint8Array([4, 0, 5, 0]));
+  await new Promise(resolve => setTimeout(resolve, 5));
+  t.equal(audioPlatform.getWebAudioDiagnostics().scheduledBuffers,
+    timedBuffersBefore + 1,
+    "a short effect flushes even when it never fills a complete region");
+  timed.end();
+  t.end();
+});
+
+test("WebAudio starts short effect lines after their first region", async (t) => {
+  const listeners = new Map();
+  let factory = null;
+  let workletOptions = null;
+  const posted = [];
+  class FakeAudioContext {
+    constructor() {
+      this.state = "running";
+      this.currentTime = 0;
+      this.sampleRate = 48000;
+      this.destination = {};
+      this.audioWorklet = { addModule: () => Promise.resolve() };
+    }
+    resume() { return Promise.resolve(); }
+  }
+  class FakeAudioWorkletNode {
+    constructor(_context, _name, options) {
+      workletOptions = options;
+      this.port = {
+        onmessage: null,
+        postMessage(message) { posted.push(message); },
+      };
+    }
+    connect() {}
+    disconnect() {}
+  }
+  const audioPlatform = {
+    setAudioOutputFactory(value) { factory = value; },
+  };
+  const fakeWindow = {
+    document: {
+      addEventListener(type, listener) { listeners.set(type, listener); },
+    },
+    AudioContext: FakeAudioContext,
+    AudioWorkletNode: FakeAudioWorkletNode,
+    Blob: class FakeBlob {},
+    URL: {
+      createObjectURL() { return "blob:worklet"; },
+      revokeObjectURL() {},
+    },
+    JVMDebug: { audioPlatform },
+  };
+  const modulePath = require.resolve("../src/platform/web-audio");
+  const previousWindow = global.window;
+  global.window = fakeWindow;
+  delete require.cache[modulePath];
+  t.teardown(() => {
+    delete require.cache[modulePath];
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  });
+
+  require(modulePath);
+  listeners.get("pointerdown")();
+  const output = factory({
+    channels: 2,
+    bitDepth: 16,
+    sampleRate: 22050,
+    signed: true,
+    bigEndian: false,
+    bufferSize: 8192,
+    coalesceDelayMs: 0,
+  });
+  await new Promise(resolve => setImmediate(resolve));
+  t.equal(workletOptions.processorOptions.startFrames, 512,
+    "the 8 KiB effect line uses its first 512-frame region, not 80 ms");
+  output.write(new Uint8Array(512 * 2 * 2));
+  const pcm = posted.find(message => message.type === "pcm");
+  t.equal(pcm && pcm.frames, 512,
+    "the first published effect region satisfies the worklet threshold");
+  t.equal(audioPlatform.getWebAudioDiagnostics().outputFormats[0]
+    .workletStartFrames, 512,
+  "telemetry exposes the per-line startup threshold");
+  output.end();
   t.end();
 });


### PR DESCRIPTION
## What changed

- retains the existing sample-generation, structured exception-resumption, and Node support fixes
- adds structurally verified, class-name-independent affine raster acceleration and broader structured/JIT runtime improvements
- preserves JVM exception/debugger state across generated execution
- fixes Java reflection array descriptors and generated reflective invocation behavior discovered by the audio probes
- implements continuous WebAudio output with capacity-aware coalescing and AudioWorklet buffering
- starts short sound-effect lines after their first natural 512-frame region while retaining the music stream's 80 ms cushion
- adds detailed reproducibility and Firefox performance documentation

## Why

DekoBloko's generated raster bodies spent excessive time crossing JVM method boundaries, while the browser represented each small Java `SourceDataLine.write` as a separate WebAudio source. That reduced rendering throughput and introduced audio resampler discontinuities. After continuity was fixed, short effects still remained inaudible because they often ended before satisfying a music-sized startup threshold.

All runtime recognition is based on descriptors, verified bytecode/CFG structure, field/call relationships, and canonical fingerprints—not guest class or method names.

## Validation

- `timeout 120s node node_modules/tape/bin/tape test/jitCompiler.test.js` — 963/963 passed
- `timeout 90s node node_modules/tape/bin/tape test/webAudio.test.js test/jreEdgeCases.test.js test/browserEntryErrors.test.js` — 134/134 passed
- `npm run build:bundle` — succeeded; webpack emitted the four existing dependency/size warnings
- DekoBloko's paired diagnostic repository reproduced one complete 250-state logo timeline with the expected sequence hash `1711060353`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated pre-test workflow to run the complete generation process, including Java build steps and an additional generation phase.
  - Added coverage for nested exception handling to verify correct structured SSA behavior when both JIT and structured modes are disabled.
  - Expanded JIT, WebAudio, and reflection edge-case test coverage, including validation against newly generated outputs.

- **Performance / Optimization**
  - Added/verified an affine sprite raster fast path with a safety fallback switch.

- **WebAudio**
  - Improved PCM streaming and coalescing via optional shared worklet usage, with richer diagnostics.

- **Correctness**
  - Hardened reflective call/return handling and Java class initialization bookkeeping.

- **CI / Documentation**
  - Simplified CI Node testing to Node 20.x and updated the README badge.
  - Added new documentation for the affine sprite raster and Firefox performance findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->