### PR TITLE
Fix array-store alias retargeting

### DIFF
--- a/src/passes/retargetUndefinedTypedAliasLoads.js
+++ b/src/passes/retargetUndefinedTypedAliasLoads.js
@@ -89,15 +89,20 @@ function findCompatibleArrayParameter(items, loadIndex, method) {
 function expectedArrayDescriptorAtUse(items, loadIndex) {
   for (let i = nextInstructionIndex(items, loadIndex), seen = 0; i >= 0 && seen < 8; i = nextInstructionIndex(items, i), seen += 1) {
     const itemOp = op(items[i]);
-    if (itemOp === 'faload' || itemOp === 'fastore') return '[F';
-    if (itemOp === 'daload' || itemOp === 'dastore') return '[D';
-    if (itemOp === 'laload' || itemOp === 'lastore') return '[J';
-    if (itemOp === 'iaload' || itemOp === 'iastore') return '[I';
-    if (itemOp === 'baload' || itemOp === 'bastore') return '[B';
-    if (itemOp === 'caload' || itemOp === 'castore') return '[C';
-    if (itemOp === 'saload' || itemOp === 'sastore') return '[S';
-    if (itemOp === 'aaload') return '[[*';
-    if (itemOp === 'aastore') return '[L*';
+    // An array load consumes the array reference and an index; an array store
+    // additionally consumes the value.  Do not infer that the starting aload
+    // is the array reference unless those intervening operands were produced.
+    // In particular, an aload immediately before aastore is its value operand,
+    // not an undefined alias of an array parameter.
+    if ((itemOp === 'faload' && seen >= 1) || (itemOp === 'fastore' && seen >= 2)) return '[F';
+    if ((itemOp === 'daload' && seen >= 1) || (itemOp === 'dastore' && seen >= 2)) return '[D';
+    if ((itemOp === 'laload' && seen >= 1) || (itemOp === 'lastore' && seen >= 2)) return '[J';
+    if ((itemOp === 'iaload' && seen >= 1) || (itemOp === 'iastore' && seen >= 2)) return '[I';
+    if ((itemOp === 'baload' && seen >= 1) || (itemOp === 'bastore' && seen >= 2)) return '[B';
+    if ((itemOp === 'caload' && seen >= 1) || (itemOp === 'castore' && seen >= 2)) return '[C';
+    if ((itemOp === 'saload' && seen >= 1) || (itemOp === 'sastore' && seen >= 2)) return '[S';
+    if (itemOp === 'aaload' && seen >= 1) return '[[*';
+    if (itemOp === 'aastore' && seen >= 2) return '[L*';
     if (itemOp === 'arraylength') return '[*';
     if (!isSimpleStackProducer(items[i])) return null;
   }

--- a/test/retargetUndefinedTypedAliasLoads.test.js
+++ b/test/retargetUndefinedTypedAliasLoads.test.js
@@ -160,3 +160,24 @@ test('skips undefined array load when compatible parameter is ambiguous', (t) =>
   t.deepEqual(code.codeItems[0].instruction, { op: 'aload', arg: '8' });
   t.end();
 });
+
+test('does not treat the reference value of aastore as an array parameter alias', (t) => {
+  const method = {
+    flags: ['static'],
+    descriptor: '([Lvl;BLvl;Z)V',
+  };
+  const code = {
+    codeItems: [
+      { instruction: { op: 'aload', arg: '5' } },
+      { instruction: { op: 'iload', arg: '6' } },
+      { instruction: { op: 'aload', arg: '7' } },
+      { instruction: 'aastore' },
+      { instruction: 'return' },
+    ],
+    exceptionTable: [],
+  };
+
+  t.equal(rewriteCode(code, method), 0);
+  t.deepEqual(code.codeItems[2].instruction, { op: 'aload', arg: '7' });
+  t.end();
+});


### PR DESCRIPTION
## What changed

- require the operand count expected by array loads and stores before inferring that an undefined `aload` is an array parameter alias
- add a regression for an `aload` used as the value operand of `aastore`

## Root cause

`retargetUndefinedTypedAliasLoads` scanned forward to the next array operation without accounting for the operand position of the candidate load. An `aload` immediately before `aastore` was therefore mistaken for the array reference, even though it was the value being stored. In Brick-a-Brac this rewrote a `cl` iterator value to the unique `vl[]` parameter, producing `ClassCastException: [Lvl; cannot be cast to cl` during gameplay.

## Impact

Generated bytecode retains the iterator value for reference-array stores, preventing the gameplay crash and the subsequent hang in the legacy client-error reporter.

## Validation

- `node test/retargetUndefinedTypedAliasLoads.test.js` (16/16 assertions)
- ran the complete safe bytecode pipeline for Brick-a-Brac `cg.class`; the fixed output is byte-for-byte identical to the control run with the pass disabled
- decompiled output now emits `var5[incrementValue$1] = var7`
- rebuilt the complete 421-class game jar; ABI verification reports 0 mismatches and the jar launches successfully

## Summary by Sourcery

Adjust array alias retargeting to respect operand positions for array loads and stores, preventing misidentification of value operands as array parameter aliases.

Bug Fixes:
- Ensure aload used as the value operand of aastore is not incorrectly treated as an array parameter alias.

Tests:
- Add a regression test covering aastore with a preceding aload value operand to guard against incorrect alias retargeting.