### PR TITLE
Preserve dup array identity across CFG edges

### DIFF
--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -3718,6 +3718,22 @@ function decompileOwnedStructuredControlFlow(code, method, cls, localState, opti
     else if (op === 'tableswitch' || op === 'lookupswitch') pop(exitStack);
     if (exitStack.some((value) => value.code.includes('stack-underflow'))) throw new Error('stack dataflow underflow');
 
+    // A dup-filled array can remain live in two operand-stack slots when a
+    // conditional splits the basic block before the element store. Rendering
+    // each outgoing slot independently would turn the one JVM allocation into
+    // two `new T[n]` expressions. Spill the shared expression once while its
+    // object identity is still visible; successor carriers then copy the same
+    // Java reference even though their expression metadata is reconstructed.
+    const exitValueCounts = new Map();
+    for (const value of exitStack) {
+      exitValueCounts.set(value, (exitValueCounts.get(value) || 0) + 1);
+    }
+    for (const [value, count] of exitValueCounts) {
+      if (!value || count < 2 || (!value.newArraySpill && !value.arrayLiteral) ||
+          !/^new\b/.test(value.code)) continue;
+      materializeNewArraySpill(value, lines, localState);
+    }
+
     // A terminal block has no outgoing operand stack.  Obfuscated methods can
     // leave dead values beneath a return instruction; materializing those as
     // stack-out assignments would place Java statements after return/throw.

--- a/src/decompiler/cfr.js
+++ b/src/decompiler/cfr.js
@@ -3718,27 +3718,30 @@ function decompileOwnedStructuredControlFlow(code, method, cls, localState, opti
     else if (op === 'tableswitch' || op === 'lookupswitch') pop(exitStack);
     if (exitStack.some((value) => value.code.includes('stack-underflow'))) throw new Error('stack dataflow underflow');
 
+    // A terminal block has no outgoing operand stack.  Obfuscated methods can
+    // leave dead values beneath a return instruction; materializing those as
+    // stack-out assignments would place Java statements after return/throw.
+    const regularSuccessors = (cfg.succ[blockId] || []).filter((successor) =>
+      successor != null && !handlerEntries.has(cfg.blocks[successor].headLabel));
+
     // A dup-filled array can remain live in two operand-stack slots when a
     // conditional splits the basic block before the element store. Rendering
     // each outgoing slot independently would turn the one JVM allocation into
     // two `new T[n]` expressions. Spill the shared expression once while its
     // object identity is still visible; successor carriers then copy the same
     // Java reference even though their expression metadata is reconstructed.
-    const exitValueCounts = new Map();
-    for (const value of exitStack) {
-      exitValueCounts.set(value, (exitValueCounts.get(value) || 0) + 1);
-    }
-    for (const [value, count] of exitValueCounts) {
-      if (!value || count < 2 || (!value.newArraySpill && !value.arrayLiteral) ||
-          !/^new\b/.test(value.code)) continue;
-      materializeNewArraySpill(value, lines, localState);
+    if (regularSuccessors.length) {
+      const exitValueCounts = new Map();
+      for (const value of exitStack) {
+        exitValueCounts.set(value, (exitValueCounts.get(value) || 0) + 1);
+      }
+      for (const [value, count] of exitValueCounts) {
+        if (!value || count < 2 || (!value.newArraySpill && !value.arrayLiteral) ||
+            !/^new\b/.test(value.code)) continue;
+        materializeNewArraySpill(value, lines, localState);
+      }
     }
 
-    // A terminal block has no outgoing operand stack.  Obfuscated methods can
-    // leave dead values beneath a return instruction; materializing those as
-    // stack-out assignments would place Java statements after return/throw.
-    const regularSuccessors = (cfg.succ[blockId] || []).filter((successor) =>
-      successor != null && !handlerEntries.has(cfg.blocks[successor].headLabel));
     if (regularSuccessors.length) exitStack.forEach((value, slot) => {
       requireRenderedTypeImport(options, value.qualifiedType || value.type);
       const rawStoredValue = renderStoreExpression(value);

--- a/test/cfrStackOrdering.test.js
+++ b/test/cfrStackOrdering.test.js
@@ -126,6 +126,41 @@ L21: areturn
 .end class
 `;
 
+const BRANCHED_REFERENCE_ARRAY_ARGUMENT = `.version 52 0
+.class public super BranchedReferenceArrayArgument
+.super java/lang/Object
+
+.method public static consume : ([Ljava/lang/String;)Ljava/lang/String;
+    .code stack 2 locals 1
+L0: aload_0
+L1: iconst_0
+L2: aaload
+L3: areturn
+    .end code
+.end method
+
+.method public static call : (Z)Ljava/lang/String;
+    .code stack 4 locals 1
+L10: iconst_1
+L11: anewarray java/lang/String
+L14: dup
+L15: iconst_0
+L16: iload_0
+L17: ifeq L26
+L20: goto L24
+L23: athrow
+L24: ldc "enabled"
+L25: goto L28
+L27: athrow
+L26: ldc "disabled"
+L28: aastore
+L29: invokestatic Method BranchedReferenceArrayArgument consume ([Ljava/lang/String;)Ljava/lang/String;
+L32: areturn
+    .end code
+.end method
+.end class
+`;
+
 const INLINE_PRIMITIVE_ARRAY_STORE = `.version 52 0
 .class public super InlinePrimitiveArrayStore
 .super java/lang/Object
@@ -452,6 +487,23 @@ test('dup-filled reference arrays retain their elements when passed directly to 
       'direct call argument includes the value recorded by aastore');
     t.notOk(/consume\(new String\[1\]\)/.test(source),
       'direct call argument is not emitted as a null-filled allocation');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  t.end();
+});
+
+test('dup-filled reference arrays retain identity across a conditional value branch', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfr-branched-array-argument-'));
+  try {
+    const source = decompileFixture(tempDir, 'BranchedReferenceArrayArgument',
+      BRANCHED_REFERENCE_ARRAY_ARGUMENT);
+    const allocations = source.match(/new String(?:\[1\]|\[\]\{)/g) || [];
+
+    t.equal(allocations.length, 1, 'the duplicated operand stack reference is allocated once');
+    t.notOk(
+      /String\[] ([A-Za-z_$][A-Za-z0-9_$]*) = new String\[1\];[\s\S]*String\[] [A-Za-z_$][A-Za-z0-9_$]* = new String\[1\]/.test(source),
+      'the conditional store and following call do not receive separate allocations');
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/cfrStackOrdering.test.js
+++ b/test/cfrStackOrdering.test.js
@@ -161,6 +161,22 @@ L32: areturn
 .end class
 `;
 
+const TERMINAL_DEAD_DUP_ARRAY = `.version 52 0
+.class public super TerminalDeadDupArray
+.super java/lang/Object
+
+.method public static value : ()I
+    .code stack 3 locals 0
+L0: iconst_1
+L1: anewarray java/lang/String
+L4: dup
+L5: bipush 7
+L7: ireturn
+    .end code
+.end method
+.end class
+`;
+
 const INLINE_PRIMITIVE_ARRAY_STORE = `.version 52 0
 .class public super InlinePrimitiveArrayStore
 .super java/lang/Object
@@ -504,6 +520,24 @@ test('dup-filled reference arrays retain identity across a conditional value bra
     t.notOk(
       /String\[] ([A-Za-z_$][A-Za-z0-9_$]*) = new String\[1\];[\s\S]*String\[] [A-Za-z_$][A-Za-z0-9_$]* = new String\[1\]/.test(source),
       'the conditional store and following call do not receive separate allocations');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  t.end();
+});
+
+test('dead duplicated arrays in terminal blocks do not emit after return', (t) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfr-terminal-dead-array-'));
+  try {
+    const source = decompileFixture(tempDir, 'TerminalDeadDupArray', TERMINAL_DEAD_DUP_ARRAY);
+
+    t.match(source, /return 7;/, 'the terminal return is retained');
+    t.notOk(/return 7;[\s\S]*new String\[1\]/.test(source),
+      'the dead duplicated allocation is not materialized after return');
+    fs.writeFileSync(path.join(tempDir, 'TerminalDeadDupArray.java'), source);
+    execFileSync('javac', ['-g:none', '-d', tempDir,
+      path.join(tempDir, 'TerminalDeadDupArray.java')]);
+    t.pass('the terminal block output recompiles without unreachable statements');
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- materialize a duplicated array allocation once before operand-stack values cross a CFG edge
- keep successor stack carriers pointing at that shared Java reference
- add an obfuscated conditional-array-fill regression matching the Brick-a-Brac crash shape

## Root cause

A JVM `dup` left the same array reference in two operand-stack slots. When an intervening conditional split the basic block, CFR-JS rendered each outgoing slot independently as `new String[1]`. The element store updated one allocation while the following method call received the other null-filled allocation.

## Impact

Recompiled Brick-a-Brac no longer throws `NullPointerException` in `rd.a` while rendering the affected UI/game state. The fix is generic and contains no game-specific class or method names.

## Validation

- CFR-JS focused suite: 224/224 assertions passed
- Brick-a-Brac owned pipeline: 420 classes and sources, zero hard, CLI, ASM, or javac failures
- ABI restoration: 420 original classes checked, zero mismatches
- instrumented runtime replay completed and remained live without the prior crash trace

## Summary by Sourcery

Ensure duplicated reference array allocations are materialized once before crossing conditional control-flow edges to preserve object identity in decompiled output.

New Features:
- Add a BranchedReferenceArrayArgument fixture exercising conditional branching with a dup-filled reference array argument.
- Add a regression test verifying that conditional branches do not cause multiple allocations for a single dup-filled reference array.

Enhancements:
- Update structured control-flow decompilation to detect duplicated exit-stack array values and spill their shared allocation once so successor stacks reuse the same reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decompilation of conditionally selected array references to ensure a single array allocation is preserved.
  * Preserved shared array identity across conditional assignments and subsequent method calls.

* **Tests**
  * Added coverage for conditional array usage and reference reuse during decompilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->