### PR TITLE
Consolidate shared instruction utilities and fix DRY violations

### DIFF
--- a/src/passes/narrowByteArrayStores.js
+++ b/src/passes/narrowByteArrayStores.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const {
+  op,
+  arg,
+  pushValue,
+  intLoadLocal,
+  objectLoadLocal,
+  objectStoreLocal,
+  parseParameterDescriptors,
+} = require('../utils/instructionUtils');
+
 function runNarrowByteArrayStores(astRoot) {
   let rewrites = 0;
   for (const cls of astRoot.classes || []) {
@@ -89,35 +99,6 @@ function isNarrowableIntValue(item) {
   return pushValue(item) != null || intLoadLocal(item) != null;
 }
 
-function objectLoadLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'aload') return String(arg(item));
-  if (/^aload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function objectStoreLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'astore') return String(arg(item));
-  if (/^astore_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function intLoadLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iload') return String(arg(item));
-  if (/^iload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function pushValue(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iconst_m1') return -1;
-  if (/^iconst_[0-5]$/.test(itemOp || '')) return Number(itemOp.slice(-1));
-  if (itemOp === 'bipush' || itemOp === 'sipush') return Number(arg(item));
-  return null;
-}
-
 function byteArrayParameterLocals(method) {
   return parameterLocals(method, '[B');
 }
@@ -136,36 +117,6 @@ function parameterLocals(method, descriptor) {
     local += (desc === 'J' || desc === 'D') ? 2 : 1;
   }
   return out;
-}
-
-function parseParameterDescriptors(descriptor) {
-  const close = descriptor.indexOf(')');
-  if (!descriptor.startsWith('(') || close < 0) return [];
-  const params = [];
-  for (let i = 1; i < close;) {
-    const start = i;
-    while (descriptor[i] === '[') i += 1;
-    if (descriptor[i] === 'L') {
-      const semi = descriptor.indexOf(';', i);
-      if (semi < 0 || semi > close) return params;
-      params.push(descriptor.slice(start, semi + 1));
-      i = semi + 1;
-    } else {
-      params.push(descriptor.slice(start, i + 1));
-      i += 1;
-    }
-  }
-  return params;
-}
-
-function op(item) {
-  const insn = item && item.instruction;
-  return typeof insn === 'string' ? insn : insn && insn.op;
-}
-
-function arg(item) {
-  const insn = item && item.instruction;
-  return insn && typeof insn === 'object' ? insn.arg : null;
 }
 
 function methodReturnsByteArray(itemArg) {

--- a/src/passes/narrowCharArrayStores.js
+++ b/src/passes/narrowCharArrayStores.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const {
+  op,
+  arg,
+  pushValue,
+  intLoadLocal,
+  intStoreLocal,
+} = require('../utils/instructionUtils');
+
 function runNarrowCharArrayStores(astRoot) {
   let rewrites = 0;
   for (const cls of astRoot.classes || []) {
@@ -64,38 +72,6 @@ function isCharProducer(item) {
   if ((itemOp === 'getstatic' || itemOp === 'getfield') && fieldDescriptor(itemArg) === 'C') return true;
   if ((itemOp === 'invokevirtual' || itemOp === 'invokeinterface' || itemOp === 'invokestatic') && methodReturnsChar(itemArg)) return true;
   return false;
-}
-
-function intLoadLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iload') return String(arg(item));
-  if (/^iload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function intStoreLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'istore') return String(arg(item));
-  if (/^istore_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function pushValue(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iconst_m1') return -1;
-  if (/^iconst_[0-5]$/.test(itemOp || '')) return Number(itemOp.slice(-1));
-  if (itemOp === 'bipush' || itemOp === 'sipush') return Number(arg(item));
-  return null;
-}
-
-function op(item) {
-  const insn = item && item.instruction;
-  return typeof insn === 'string' ? insn : insn && insn.op;
-}
-
-function arg(item) {
-  const insn = item && item.instruction;
-  return insn && typeof insn === 'object' ? insn.arg : null;
 }
 
 function methodReturnsChar(itemArg) {

--- a/src/passes/narrowShortArrayStores.js
+++ b/src/passes/narrowShortArrayStores.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const {
+  op,
+  arg,
+  pushValue,
+  intLoadLocal,
+  objectLoadLocal,
+  objectStoreLocal,
+  parseParameterDescriptors,
+} = require('../utils/instructionUtils');
+
 function runNarrowShortArrayStores(astRoot) {
   let rewrites = 0;
   for (const cls of astRoot.classes || []) {
@@ -88,35 +98,6 @@ function isNarrowableIntValue(item) {
   return pushValue(item) != null || intLoadLocal(item) != null;
 }
 
-function objectLoadLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'aload') return String(arg(item));
-  if (/^aload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function objectStoreLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'astore') return String(arg(item));
-  if (/^astore_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function intLoadLocal(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iload') return String(arg(item));
-  if (/^iload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
-  return null;
-}
-
-function pushValue(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iconst_m1') return -1;
-  if (/^iconst_[0-5]$/.test(itemOp || '')) return Number(itemOp.slice(-1));
-  if (itemOp === 'bipush' || itemOp === 'sipush') return Number(arg(item));
-  return null;
-}
-
 function parameterLocals(method, descriptor) {
   const out = [];
   if (!method || typeof method.descriptor !== 'string') return out;
@@ -127,26 +108,6 @@ function parameterLocals(method, descriptor) {
     local += (desc === 'J' || desc === 'D') ? 2 : 1;
   }
   return out;
-}
-
-function parseParameterDescriptors(descriptor) {
-  const close = descriptor.indexOf(')');
-  if (!descriptor.startsWith('(') || close < 0) return [];
-  const params = [];
-  for (let i = 1; i < close;) {
-    const start = i;
-    while (descriptor[i] === '[') i += 1;
-    if (descriptor[i] === 'L') {
-      const semi = descriptor.indexOf(';', i);
-      if (semi < 0 || semi > close) return params;
-      params.push(descriptor.slice(start, semi + 1));
-      i = semi + 1;
-    } else {
-      params.push(descriptor.slice(start, i + 1));
-      i += 1;
-    }
-  }
-  return params;
 }
 
 function methodReturns(itemArg, descriptor) {
@@ -162,16 +123,6 @@ function fieldDescriptor(itemArg) {
     Array.isArray(itemArg[2])
     ? itemArg[2][1]
     : null;
-}
-
-function op(item) {
-  const insn = item && item.instruction;
-  return typeof insn === 'string' ? insn : insn && insn.op;
-}
-
-function arg(item) {
-  const insn = item && item.instruction;
-  return insn && typeof insn === 'object' ? insn.arg : null;
 }
 
 module.exports = { runNarrowShortArrayStores, narrowCodeItems, collectShortArrayLocals };

--- a/src/passes/simplifyNotCompare.js
+++ b/src/passes/simplifyNotCompare.js
@@ -1,5 +1,13 @@
 'use strict';
 
+const {
+  op,
+  arg,
+  pushValue: utilsPushValue,
+  intLoadLocal,
+  parseParameterDescriptors,
+} = require('../utils/instructionUtils');
+
 const LEFT_OPS = {
   if_icmpgt: 'if_icmplt',
   if_icmpge: 'if_icmple',
@@ -339,17 +347,13 @@ function isIntLoad(item) {
 }
 
 function localIndex(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iload') return String(arg(item));
-  return itemOp.slice(-1);
+  return intLoadLocal(item);
 }
 
 function pushValue(item) {
-  const itemOp = op(item);
-  if (itemOp === 'iconst_m1') return -1;
-  if (/^iconst_[0-5]$/.test(itemOp || '')) return Number(itemOp.slice(-1));
-  if (itemOp === 'bipush' || itemOp === 'sipush') return Number(arg(item));
-  if (itemOp === 'ldc') {
+  const val = utilsPushValue(item);
+  if (val != null) return val;
+  if (op(item) === 'ldc') {
     const value = arg(item);
     return Number.isInteger(value) ? value : null;
   }
@@ -362,16 +366,6 @@ function pushInstruction(value) {
   if (value >= -128 && value <= 127) return { op: 'bipush', arg: String(value) };
   if (value >= -32768 && value <= 32767) return { op: 'sipush', arg: String(value) };
   return { op: 'ldc', arg: value };
-}
-
-function op(item) {
-  const insn = item && item.instruction;
-  return typeof insn === 'string' ? insn : insn && insn.op;
-}
-
-function arg(item) {
-  const insn = item && item.instruction;
-  return insn && typeof insn === 'object' ? insn.arg : null;
 }
 
 function collectUsedLabels(codeItems = [], exceptionTable = []) {
@@ -422,26 +416,6 @@ function charParameterLocals(method) {
     local += (desc === 'J' || desc === 'D') ? 2 : 1;
   }
   return out;
-}
-
-function parseParameterDescriptors(descriptor) {
-  const close = descriptor.indexOf(')');
-  if (!descriptor.startsWith('(') || close < 0) return [];
-  const params = [];
-  for (let i = 1; i < close;) {
-    let start = i;
-    while (descriptor[i] === '[') i += 1;
-    if (descriptor[i] === 'L') {
-      const semi = descriptor.indexOf(';', i);
-      if (semi < 0 || semi > close) return params;
-      params.push(descriptor.slice(start, semi + 1));
-      i = semi + 1;
-    } else {
-      params.push(descriptor.slice(start, i + 1));
-      i += 1;
-    }
-  }
-  return params;
 }
 
 function methodReturnsChar(itemArg) {

--- a/src/utils/instructionUtils.js
+++ b/src/utils/instructionUtils.js
@@ -457,8 +457,83 @@ function parseLocalOperation(normalized, original) {
   return null;
 }
 
+function op(item) {
+  const insn = item && item.instruction;
+  return typeof insn === 'string' ? insn : insn && insn.op;
+}
+
+function arg(item) {
+  const insn = item && item.instruction;
+  return insn && typeof insn === 'object' ? insn.arg : null;
+}
+
+function pushValue(item) {
+  const itemOp = op(item);
+  if (itemOp === 'iconst_m1') return -1;
+  if (/^iconst_[0-5]$/.test(itemOp || '')) return Number(itemOp.slice(-1));
+  if (itemOp === 'bipush' || itemOp === 'sipush') return Number(arg(item));
+  return null;
+}
+
+function intLoadLocal(item) {
+  const itemOp = op(item);
+  if (itemOp === 'iload') return String(arg(item));
+  if (/^iload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
+  return null;
+}
+
+function intStoreLocal(item) {
+  const itemOp = op(item);
+  if (itemOp === 'istore') return String(arg(item));
+  if (/^istore_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
+  return null;
+}
+
+function objectLoadLocal(item) {
+  const itemOp = op(item);
+  if (itemOp === 'aload') return String(arg(item));
+  if (/^aload_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
+  return null;
+}
+
+function objectStoreLocal(item) {
+  const itemOp = op(item);
+  if (itemOp === 'astore') return String(arg(item));
+  if (/^astore_[0-3]$/.test(itemOp || '')) return itemOp.slice(-1);
+  return null;
+}
+
+function parseParameterDescriptors(descriptor) {
+  if (!descriptor || typeof descriptor !== 'string') return [];
+  const close = descriptor.indexOf(')');
+  if (!descriptor.startsWith('(') || close < 0) return [];
+  const params = [];
+  for (let i = 1; i < close;) {
+    const start = i;
+    while (descriptor[i] === '[') i += 1;
+    if (descriptor[i] === 'L') {
+      const semi = descriptor.indexOf(';', i);
+      if (semi < 0 || semi > close) return params;
+      params.push(descriptor.slice(start, semi + 1));
+      i = semi + 1;
+    } else {
+      params.push(descriptor.slice(start, i + 1));
+      i += 1;
+    }
+  }
+  return params;
+}
+
 module.exports = {
   getStackEffect,
   normalizeInstruction,
   parseLocalOperation,
+  op,
+  arg,
+  pushValue,
+  intLoadLocal,
+  intStoreLocal,
+  objectLoadLocal,
+  objectStoreLocal,
+  parseParameterDescriptors,
 };


### PR DESCRIPTION
Consolidates duplicate instruction helper functions (op, arg, pushValue, intLoadLocal, intStoreLocal, objectLoadLocal, objectStoreLocal) and parseParameterDescriptors into src/utils/instructionUtils.js and refactors AST optimization passes (narrowByteArrayStores, narrowCharArrayStores, narrowShortArrayStores, simplifyNotCompare) to import them.

---
*PR created automatically by Jules for task [161190381948273565](https://jules.google.com/task/161190381948273565) started by @Kreijstal*

## Summary by Sourcery

Consolidate duplicated instruction helpers into a shared utility module and update optimization passes to use it.

Enhancements:
- Centralize shared instruction parsing, constant extraction, local access, and parameter descriptor utilities for reuse across AST optimization passes.
- Refactor byte, char, short array store narrowing and comparison simplification passes to consume the shared instruction utilities.